### PR TITLE
fix: remove local version for scm

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/rock_physics_open/version.py"
+version_scheme = "only-version"
+local_scheme = "no-local-version"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
pypi does not allow local version so this needs to be disabled in setuptools_scm