### PR TITLE
fix: make get_snapshot_name more robust in search for calling function

### DIFF
--- a/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/compare_snapshots.py
+++ b/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/compare_snapshots.py
@@ -11,18 +11,19 @@ from rock_physics_open.equinor_utilities.various_utilities import disp_result_st
 
 from .snapshots import get_snapshot_name
 
-DISPLAY_RESULTS = False
-
 
 def compare_snapshots(
     test_results: Union[np.ndarray, tuple, DataFrame],
     saved_results: tuple,
+    name_arr=None,
+    display_results: bool = False,
 ) -> bool:
     test_results = _validate_input(test_results, saved_results)
 
-    if DISPLAY_RESULTS:
+    if display_results:
         title = str(inspect.stack()[1].function)
-        name_arr = [f"arr_{i}" for i in range(len(test_results))]
+        if not name_arr:
+            name_arr = [f"arr_{i}" for i in range(len(test_results))]
         disp_result_stats(title, test_results, name_arr)
 
     r_tol = 0.01

--- a/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/snapshots.py
+++ b/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/snapshots.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 from pathlib import Path
 
 import numpy as np
@@ -18,22 +17,24 @@ def get_snapshot_name(step: int = 1, include_snapshot_dir=True) -> str:
     -------
     name of snapshot file
     """
-    # Get the stack trace
     trace = inspect.stack()
-
-    # Find the first frame that is not part of the debugger
     for frame in trace[step:]:
-        if not any(keyword in frame.filename for keyword in
-                   ["pydev", "ipython-input", "interactiveshell", "async_helpers"]):  # Skip debugger-related frames
-            dir_name = Path(frame.filename).parent.joinpath("snapshots")
-            file_name = "_".join((Path(frame.filename).stem, frame.function + ".npz"))
-            return os.path.join(dir_name, file_name) if include_snapshot_dir else file_name
+        if not any(
+            keyword in frame.filename
+            for keyword in [
+                "pydev",
+                "ipython-input",
+                "interactiveshell",
+                "async_helpers",
+            ]
+        ):
+            break
+    else:
+        frame = trace[step]
 
-    # Fallback to the original step if no valid frame is found
-    frame = trace[step]
-    dir_name = Path(frame.filename).parent.joinpath("snapshots")
-    file_name = "_".join((Path(frame.filename).stem, frame.function + ".npz"))
-    return os.path.join(dir_name, file_name) if include_snapshot_dir else file_name
+    dir_name = Path(frame.filename).parent / "snapshots"
+    file_name = f"{Path(frame.filename).stem}_{frame.function}.npz"
+    return str(dir_name / file_name) if include_snapshot_dir else file_name
 
 
 def store_snapshot(snapshot_name: str, *args: np.ndarray) -> bool:


### PR DESCRIPTION
Earlier assumption that calling function would always be two steps up the stack is not valid when called from debugger or from external process such as RokDoc.