### PR TITLE
test: Drop unittest support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,9 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]
+
+[tool.pytest.ini_options]
+markers = [
+    "use_graphics", # marks test as dependent on display (deselect with '-m "not use_graphics")]
+]
+addopts = ["--color=yes", "--strict-markers"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-markers =
-    use_graphics: marks test as dependent on display (deselect with '-m "not use_graphics")
-
-filterwarnings =
-    ignore::DeprecationWarning

--- a/tests/classification_functions_tests/test_class_stats.py
+++ b/tests/classification_functions_tests/test_class_stats.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.classification_functions import gen_class_stats
 
 
-class ClassStatsTestCase(unittest.TestCase):
+class TestClassStats:
     def test_class_stats(self):
         rg = default_rng(234769238476)
         obs = rg.random((100, 2))
@@ -41,7 +39,3 @@ class ClassStatsTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
         np.testing.assert_equal(class_counts, class_count_ref)
         np.testing.assert_equal(class_id, class_id_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/classification_functions_tests/test_lin_class.py
+++ b/tests/classification_functions_tests/test_lin_class.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.classification_functions import lin_class
 
 
-class LinClassTestCase(unittest.TestCase):
+class TestLinClass:
     def test_lin_class(self):
         rg = default_rng(234769238476)
         obs = rg.random((11, 2))
@@ -37,7 +35,3 @@ class LinClassTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(lin_class_arr, lin_class_ref)
         np.testing.assert_almost_equal(lin_dist, lin_dist_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/classification_functions_tests/test_mahal_class.py
+++ b/tests/classification_functions_tests/test_mahal_class.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.classification_functions import mahal_class
 
 
-class MahalClassTestCase(unittest.TestCase):
+class TestMahalClass:
     def test_mahal_class(self):
         rg = default_rng(234769238476)
         obs = rg.random((11, 2))
@@ -128,7 +126,3 @@ class MahalClassTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(mahal_class_arr, mahal_class_ref)
         np.testing.assert_almost_equal(mahal_dist, mahal_dist_ref)
         np.testing.assert_almost_equal(mahal_pp, mahal_pp_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/classification_functions_tests/test_norm_class.py
+++ b/tests/classification_functions_tests/test_norm_class.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.classification_functions import norm_class
 
 
-class NormClassTestCase(unittest.TestCase):
+class TestNormClass:
     def test_norm_class(self):
         rg = default_rng(234769238476)
         obs = rg.random((11, 2))
@@ -130,7 +128,3 @@ class NormClassTestCase(unittest.TestCase):
         np.testing.assert_equal(norm_class_arr, norm_class_ref)
         np.testing.assert_almost_equal(norm_dist, norm_dist_ref)
         np.testing.assert_almost_equal(norm_pp, norm_pp_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/classification_functions_tests/test_poly_class.py
+++ b/tests/classification_functions_tests/test_poly_class.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.classification_functions import poly_class
 
 
-class PolyClassTestCase(unittest.TestCase):
+class TestPolyClass:
     def test_poly_class(self):
         rg = default_rng(234769238476)
         obs = rg.random((11, 2))
@@ -39,7 +37,3 @@ class PolyClassTestCase(unittest.TestCase):
         poly_class_arr = poly_class(obs, class_poly, class_id)
         poly_class_ref = np.array([1, 3, 1, 2, 2, 1, 3, 2, 0, 2, 1])
         np.testing.assert_equal(poly_class_arr, poly_class_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/classification_functions_tests/test_two_step_class.py
+++ b/tests/classification_functions_tests/test_two_step_class.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
@@ -8,7 +6,7 @@ from rock_physics_open.equinor_utilities.classification_functions import (
 )
 
 
-class TwoStepClassTestCase(unittest.TestCase):
+class TestTwoStepClass:
     def test_mahal_class_thresh(self):
         rg = default_rng(238476)
         obs = rg.random((11, 2))
@@ -50,7 +48,3 @@ class TwoStepClassTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
         np.testing.assert_almost_equal(class_cov, class_cov_ref)
         np.testing.assert_almost_equal(mean_class_id, class_mean_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/gen_utilities_tests/test_dict_to_float.py
+++ b/tests/gen_utilities_tests/test_dict_to_float.py
@@ -1,15 +1,9 @@
-import unittest
-
 from rock_physics_open.equinor_utilities.gen_utilities import dict_value_to_float
 
 
-class DictToFloatTestCase(unittest.TestCase):
+class TestDictToFloat:
     def test_dict_to_float(self):
         inp_dict = {"a": "1.0", "b": "2", "d": "[1.2, 4.5]", "e": "-3"}
         ref_dict = {"a": 1.0, "b": 2.0, "d": [1.2, 4.5], "e": -3.0}
         out_dict = dict_value_to_float(inp_dict)
         assert out_dict == ref_dict
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/gen_utilities_tests/test_dim_check_vector.py
+++ b/tests/gen_utilities_tests/test_dim_check_vector.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.gen_utilities import dim_check_vector
 
 
-class DimCheckVectorTestCase(unittest.TestCase):
+class TestDimCheckVector:
     def test_dim_check_vector_ok(self):
         a = np.ones(11)
         b = 42
@@ -32,7 +30,3 @@ class DimCheckVectorTestCase(unittest.TestCase):
         assert a_out.dtype == a_ref.dtype
         assert b_out.dtype != b_ref.dtype
         assert c_out.dtype != c_ref.dtype
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/gen_utilities_tests/test_filter_input.py
+++ b/tests/gen_utilities_tests/test_filter_input.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.gen_utilities import filter_input_log
 
 
-class FilterInputTestCase(unittest.TestCase):
+class TestFilterInput:
     def test_filter_input(self):
         a = np.ones(11).astype(float)
         a[4] = np.nan
@@ -87,7 +85,3 @@ class FilterInputTestCase(unittest.TestCase):
         np.testing.assert_equal(idx, idx_ref)
         np.testing.assert_equal(a_out, a_ref)
         np.testing.assert_equal(b_out, b_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/gen_utilities_tests/test_filter_output.py
+++ b/tests/gen_utilities_tests/test_filter_output.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.gen_utilities import filter_output
 
 
-class FilterOutputTestCase(unittest.TestCase):
+class TestFilterOutput:
     def test_filter_output(self):
         a_inp = np.linspace(0, 1, 11)
         b_inp = np.linspace(0, 1, 11) * 2
@@ -19,7 +17,3 @@ class FilterOutputTestCase(unittest.TestCase):
         a_out, b_out = filter_output(idx, (a_inp, b_inp))
         np.testing.assert_equal(a_out, a_ref)
         np.testing.assert_equal(b_out, b_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_backus_average.py
+++ b/tests/std_functions_tests/test_backus_average.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import backus_average
 
 
-class BackusAverageTest(unittest.TestCase):
+class TestBackusAverage:
     def test_back_ave(self):
         vp1i = np.ones(10) * 3500.0
         vp2i = np.ones(10) * 2800.0

--- a/tests/std_functions_tests/test_dvorkin_nur.py
+++ b/tests/std_functions_tests/test_dvorkin_nur.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import dvorkin_contact_cement
 
 
-class DvorkinNurTest(unittest.TestCase):
+class TestDvorkinNur:
     def test_dvorkin_nur(self):
         frac_cem = np.linspace(0.01, 0.1, 10)
         por0_sst = 0.4 * np.ones(10)

--- a/tests/std_functions_tests/test_gassmann.py
+++ b/tests/std_functions_tests/test_gassmann.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import (
@@ -9,7 +7,7 @@ from rock_physics_open.equinor_utilities.std_functions import (
 )
 
 
-class GassmannTest(unittest.TestCase):
+class TestGassmann:
     def setup_gassmann(self):
         k_brine = np.array([2.8e9, 2.8e9, 2.8e9])
         phie = np.array([0.0, 0.35, 0.1])

--- a/tests/std_functions_tests/test_hashin_shtrikman.py
+++ b/tests/std_functions_tests/test_hashin_shtrikman.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import (
@@ -10,7 +8,7 @@ from rock_physics_open.equinor_utilities.std_functions import (
 )
 
 
-class HashinShtrikmanTest(unittest.TestCase):
+class TestHashinShtrikman:
     def setup_hs(self):
         k1 = np.ones(11) * 36.6e9
         mu1 = np.ones(11) * 44.0e9

--- a/tests/std_functions_tests/test_hertz_mindlin.py
+++ b/tests/std_functions_tests/test_hertz_mindlin.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import hertz_mindlin
 
 
-class HertzMindlinTestCase(unittest.TestCase):
+class TestHertzMindlin:
     def test_hertz_mindlin(self):
         k1 = np.ones(11) * 36.6e9
         mu1 = np.ones(11) * 44.0e9
@@ -46,7 +44,3 @@ class HertzMindlinTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(k_dry / 1e9, k_dry_ref)
         np.testing.assert_almost_equal(mu_dry / 1e9, mu_dry_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_moduli_velocity.py
+++ b/tests/std_functions_tests/test_moduli_velocity.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import moduli, velocity
 
 
-class ModuliVelocityTestCase(unittest.TestCase):
+class TestModuliVelocity:
     def test_moduli(self):
         vp = np.linspace(0.8, 1.2, 11) * 3500.0
         vs = np.linspace(0.8, 1.2, 11) * 1200.0
@@ -91,7 +89,3 @@ class ModuliVelocityTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(vs, vs_ref)
         np.testing.assert_almost_equal(ai, ai_ref)
         np.testing.assert_almost_equal(vp_vs, vp_vs_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_reflectivity.py
+++ b/tests/std_functions_tests/test_reflectivity.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
@@ -13,7 +11,7 @@ theta = np.ones(11)
 k = 1.9
 
 
-class ReflectivityTestCase(unittest.TestCase):
+class TestReflectivity:
     def test_aki_richards(self):
         r_aki_rich = aki_richards(vp, vs, rho, theta, k=2.0)
         r_aki_rich_ref = np.array(
@@ -51,7 +49,3 @@ class ReflectivityTestCase(unittest.TestCase):
             ]
         )
         np.testing.assert_almost_equal(r_sm_gi, r_sm_gi_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_rho.py
+++ b/tests/std_functions_tests/test_rho.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 import pytest
 
 from rock_physics_open.equinor_utilities.std_functions import rho_b, rho_m
 
 
-class RhoTest(unittest.TestCase):
+class TestRho:
     def test_rhob(self):
         phi = np.linspace(0.0, 0.25, 10)
         rho_fluid = 1000 * np.ones_like(phi)

--- a/tests/std_functions_tests/test_voigt_reuss_hill.py
+++ b/tests/std_functions_tests/test_voigt_reuss_hill.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import (
@@ -16,7 +14,7 @@ mu2 = np.ones(11) * 32.0e9
 f1 = np.linspace(0, 1, 11)
 
 
-class VoigtReussHillTestCase(unittest.TestCase):
+class TestVoigtReussHill:
     def test_voigt(self):
         k_v, mu_v = voigt(k1, mu1, k2, mu2, f1)
         k_v_ref = np.array(
@@ -132,7 +130,3 @@ class VoigtReussHillTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(k_m_vrh / 1.0e9, k_m_vrh_ref)
         np.testing.assert_almost_equal(mu_m_vrh / 1.0e9, mu_m_vrh_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_walton.py
+++ b/tests/std_functions_tests/test_walton.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from rock_physics_open.equinor_utilities.std_functions import walton_smooth
 
 
-class WaltonTestCase(unittest.TestCase):
+class TestWalton:
     def test_walton_smooth(self):
         k = np.ones(11) * 36.8e9
         mu = np.ones(11) * 44.0e9
@@ -84,7 +82,3 @@ class WaltonTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(k_dry / 1.0e9, k_dry_ref)
         np.testing.assert_almost_equal(mu_dry / 1.0e9, mu_dry_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/std_functions_tests/test_wood_brie.py
+++ b/tests/std_functions_tests/test_wood_brie.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.std_functions import brie, wood
 
 
-class WoodBrieTestCase(unittest.TestCase):
+class TestWoodBrie:
     def setup(self):
         s_gas = np.array([1.0, 0.0, 0.0])
         s_brine = np.array([0.0, 1.0, 0.0])
@@ -77,7 +75,3 @@ class WoodBrieTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(k_w, k_w_ref)
         np.testing.assert_almost_equal(k_b / 1e9, k_b_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/various_utilities_tests/test_hs_average.py
+++ b/tests/various_utilities_tests/test_hs_average.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.various_utilities import hs_average
 
 
-class HSTestCase(unittest.TestCase):
+class TestHS:
     def test_hashin_shtrikman_average(self):
         rg = default_rng(42)
         f = rg.random(10)
@@ -47,7 +45,3 @@ class HSTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(vp, vp_ref)
         np.testing.assert_almost_equal(vs, vs_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/various_utilities_tests/test_pressure.py
+++ b/tests/various_utilities_tests/test_pressure.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.various_utilities import pressure
 
 
-class PressureTestCase(unittest.TestCase):
+class TestPressure:
     def test_pressure(self):
         rg = default_rng(987654321)
         rho = 2650 * (0.8 + 0.2 * rg.random(11))
@@ -93,7 +91,3 @@ class PressureTestCase(unittest.TestCase):
         )
         np.testing.assert_almost_equal(p_lith, p_lith_ref)
         np.testing.assert_almost_equal(p_eff, p_eff_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/various_utilities_tests/test_reflectivity.py
+++ b/tests/various_utilities_tests/test_reflectivity.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pytest
 from numpy.random import default_rng
@@ -7,8 +5,9 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.various_utilities import reflectivity
 
 
-class ReflectivityTestCase(unittest.TestCase):
-    def setUp(self):
+class TestReflectivity:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         rg = default_rng(5947037623874)
         self.vp = 3500 * (1.0 + 0.2 * rg.random(11))
         self.vs = 1200 * (1.0 + 0.4 * rg.random(11))
@@ -73,7 +72,3 @@ class ReflectivityTestCase(unittest.TestCase):
                 k=self.k,
                 model="AkiRichards",
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/various_utilities_tests/test_time_shift.py
+++ b/tests/various_utilities_tests/test_time_shift.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
@@ -9,7 +7,7 @@ from rock_physics_open.equinor_utilities.various_utilities import (
 )
 
 
-class TimeShiftTestCase(unittest.TestCase):
+class TestTimeShift:
     def test_time_shift_ps(self):
         rg = default_rng(672190547)
         tvd = np.linspace(1900.0, 2100.0, 11)
@@ -61,7 +59,3 @@ class TimeShiftTestCase(unittest.TestCase):
         twt_ref = 2.0 * owt_ref
         np.testing.assert_almost_equal(owt_pp_shift, owt_ref)
         np.testing.assert_almost_equal(twt_pp_shift, twt_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/various_utilities_tests/test_vrh_3_min.py
+++ b/tests/various_utilities_tests/test_vrh_3_min.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.various_utilities import min_3_voigt_reuss_hill
 
 
-class Min3VRHTestCase(unittest.TestCase):
+class TestMin3VRH:
     def test_3_mineral_voigt_reuss_hill(self):
         rg = default_rng(260363)
         f1 = 0.33 * rg.random(11)
@@ -72,7 +70,3 @@ class Min3VRHTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(vp, vp_ref)
         np.testing.assert_almost_equal(vs, vs_ref)
         np.testing.assert_almost_equal(rho, rho_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Closes #56 

Remove unittest related code. 

Moved `pytest.ini` into `pyproject.toml`. Removed the ignore on deprecation warnings as there currently aren't any. Also added color to the pytest output 🌈 

To help pytest with auto-discovery, the test class names were renamed to be prefixed with `Test`