### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/rock-physics-open/security/code-scanning/9](https://github.com/equinor/rock-physics-open/security/code-scanning/9)

To correct the flagged issue, explicitly specify the minimal necessary permissions for GITHUB_TOKEN at the workflow level. In this specific file, no job appears to require more than read permission on repository contents (needed by `actions/checkout`), so setting `permissions: contents: read` at the root level (immediately after the workflow `name:` declaration) ensures principle of least privilege is observed. No other jobs in the file appear to push, create issues, or interact with the repository beyond what checkout needs. Therefore, edit `.github/workflows/test.yaml` to add these lines after the `name: test` line, before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
