### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -1,4 +1,6 @@
 name: lint-and-format
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/rock-physics-open/security/code-scanning/6](https://github.com/equinor/rock-physics-open/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block to restrict the access level of the GITHUB_TOKEN for this workflow. Since this job checks out code to run linting and formatting (static analysis, not mutating code or making PRs), the minimum required permission is `contents: read`, which allows read-only access to repository contents.

The best way to implement this is to add the following lines after the workflow `name:` key, but before the `on:` section (i.e., as a workflow-global block): 

```yaml
permissions:
  contents: read
```

No new methods, imports, or definitions are required. Only the .github/workflows/lint-and-format.yaml file needs editing, adding two lines after the first line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
