### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -21,6 +21,8 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     needs: release-please
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/rock-physics-open/security/code-scanning/4](https://github.com/equinor/rock-physics-open/security/code-scanning/4)

To remediate this, an explicit `permissions` block should be added to the `build` job. The minimal necessary permission for such a job is almost always `contents: read`, which grants read-only access to repository content necessary for checkout, but not for making changes or accessing secrets. The new block should be added directly under `runs-on: ubuntu-latest` in the `build` job within `.github/workflows/on-push-main.yaml`. No new libraries or external code are needed—simply a YAML block insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
