### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -1,5 +1,8 @@
 name: push to main branch
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,6 +17,10 @@ jobs:
 
   release-please:
     needs: test
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/release-please.yaml
 
   build:
@@ -21,8 +28,6 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     needs: release-please
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -53,7 +58,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/rock-physics-open
     permissions:
-      id-token: write  # required for Trusted Publishing to PyPI
+      id-token: write # required for Trusted Publishing to PyPI
 
     steps:
       - name: Download Artifact


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/rock-physics-open/security/code-scanning/3](https://github.com/equinor/rock-physics-open/security/code-scanning/3)

To fix the problem, we should add a `permissions:` block at the root of the workflow, restricting all jobs to the minimum required permissions unless overridden at the job level. This prevents jobs from inheriting dangerous write permissions. The root-level block will apply to all jobs unless those jobs define their own `permissions:`.

In `.github/workflows/on-push-main.yaml`, add a root-level `permissions:` block (after the `name:` and before the `jobs:`), starting with the safest default: `contents: read`. This grants read-only access to workflow jobs, which is sufficient for jobs that only need to fetch code or metadata. Jobs requiring broader permissions should keep or define their own job-level `permissions:` blocks (as already done for `build` and `publish`). No changes are needed for those jobs.

So:
- Insert  
  ```yaml
  permissions:
    contents: read
  ```
  between line 2 and line 3.
- No changes required for existing job-level permission blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
