### PR TITLE
fix: Move typing-extensions to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,9 @@ dependencies = [
     "matplotlib >= 3.7.1",
     "scipy >= 1.10.1, < 2",
     "scikit-learn >= 1.2.2",
-    "sympy >= 1.13.3",       # TODO: remove? (only used 1 place in span_wagner co2 equations)
+    "sympy >= 1.13.3",           # TODO: remove? (only used 1 place in span_wagner co2 equations)
     "tmatrix >= 1.0.0",
+    "typing-extensions>=4.15.0",
 ]
 
 
@@ -79,7 +80,6 @@ dev = [
     "pytest-cov>=6.2.1",
     "ruff>=0.12.11",
     "scipy-stubs>=1.16.1.1",
-    "typing-extensions>=4.15.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -908,6 +908,7 @@ dependencies = [
     { name = "scipy" },
     { name = "sympy" },
     { name = "tmatrix" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -920,7 +921,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "scipy-stubs" },
-    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -932,6 +932,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.10.1,<2" },
     { name = "sympy", specifier = ">=1.13.3" },
     { name = "tmatrix", specifier = ">=1.0.0" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -944,7 +945,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.11" },
     { name = "scipy-stubs", specifier = ">=1.16.1.1" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Having `typing_extensions` in dev-dependencies causes dependent packages to fail for python 3.13 unless they also have `typing_extensions` installed. See https://github.com/equinor/rock-physics/actions/runs/20025831534/job/57422878520 for more info. 

By putting it in dependencies, this will work no matter if the dependent package has `typing_extensions`  or not