### PR TITLE
fix: Remove workaround for fixed pandas bug (#57)

### DIFF
--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
@@ -74,12 +74,9 @@ def filter_input_log(
 
     # If any of the input logs are of type boolean, False means that they should not be included,
     # regardless of filter flags
-    # https://github.com/pandas-dev/pandas/issues/32432
-    # idx = ~logs.any(bool_only=True, axis=1)
-    # Need to do it the cumbersome way for the time being
     bool_col = logs.dtypes == "bool"
     if any(bool_col):
-        idx = ~logs.loc[:, logs.columns[bool_col]].any(axis=1)
+        idx = ~logs.any(bool_only=True, axis=1)
         logs.drop(columns=logs.columns[bool_col], inplace=True)
     else:
         idx = pd.Series(index=logs.index, data=np.zeros_like(logs.index).astype(bool))


### PR DESCRIPTION
The pandas bug (https://github.com/pandas-dev/pandas/issues/32432) where DataFrame.any(bool_only=True, axis=1) did not work correctly has been fixed since pandas 2.0. Since the project requires pandas >= 2.0.2, the workaround of manually selecting boolean columns is no longer needed.

Replace the manual boolean column selection with the simpler logs.any(bool_only=True, axis=1) call. The conditional check for boolean columns is retained because when no boolean columns exist, bool_only=True returns all False which when negated would incorrectly mark all rows for removal.

Closes #57