### PR TITLE
refactor: remove the need for `pytest -m "not use_graphics"`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,9 +32,4 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Test
-        if: ${{ matrix.os == 'windows-latest' }}
         run: uv run pytest
-
-      - name: Test ( -m "not use_graphics" )
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: uv run pytest -m "not use_graphics"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,16 +53,6 @@ pytest --cov=rock_physics_open
 
 </details>
 
-<details>
-<summary>Im getting <code>No module named '_tkinter'</code> error when running the tests?</summary>
-
-You can skip these graphics tests by doing:
-```sh
-pytest -m "not use_graphics"
-```
-
-</details>
-
 ### Pull-Requests
 
 - should only solve a single problem/issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ combine-as-imports = true
 "*.ipynb" = ["E402", "E501"]
 
 [tool.pytest.ini_options]
-markers = [
-    "use_graphics", # marks test as dependent on display (deselect with '-m "not use_graphics")]
-]
 addopts = ["--color=yes", "--strict-markers"]
 
 [tool.basedpyright]

--- a/src/rock_physics_open/ternary_plots/ternary_plot_utilities.py
+++ b/src/rock_physics_open/ternary_plots/ternary_plot_utilities.py
@@ -38,10 +38,18 @@ def set_ternary_figure(
         pix_y = ctypes.windll.gdi32.GetDeviceCaps(dc, VERTRES)
     elif platform.system() == "Linux":
         f = os.popen("xrandr | grep '*'")
-        pix_x, pix_y = np.array(re.findall(r"\d+", f.read()), dtype=int)[0:2]
+        matches = re.findall(r"\d+", f.read())
+        if len(matches) >= 2:
+            pix_x, pix_y = np.array(matches, dtype=int)[0:2]
+        else:
+            pix_x, pix_y = 1920, 1080
     elif platform.system() == "Darwin":
         f = os.popen("system_profiler SPDisplaysDataType | grep Resolution")
-        pix_x, pix_y = np.array(re.findall(r"\d+", f.read()), dtype=int)[0:2]
+        matches = re.findall(r"\d+", f.read())
+        if len(matches) >= 2:
+            pix_x, pix_y = np.array(matches, dtype=int)[0:2]
+        else:
+            pix_x, pix_y = 1920, 1080
     else:
         raise ValueError("Unrecognised operating system")
 
@@ -49,22 +57,23 @@ def set_ternary_figure(
     fig = plt.figure(title, facecolor=(0.9, 0.9, 0.9))
     # Set figure size and position
     mngr = plt.get_current_fig_manager()
-    if platform.system() == "Windows":
-        wid = int(pix_x * 0.4)
-        hei = int(pix_y * 0.6)
-        start_x = int(pix_x * (0.1 + delta_x / 5))
-        start_y = int(pix_y * (0.1 + delta_y / 10))
-        mngr.window.wm_geometry(  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType] | Incomplete type hints in matplotlib
-            "{}x{}+{}+{}".format(wid, hei, start_x, start_y),
-        )
-    else:
-        wid = int(pix_x * 0.2)
-        hei = int(pix_y * 0.6)
-        start_x = int(pix_x * (0.1 + delta_x / 5))
-        start_y = int(pix_y * (0.1 + delta_y / 10))
-        mngr.window.wm_geometry(  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType] | Incomplete type hints in matplotlib
-            "{}x{}+{}+{}".format(wid, hei, start_x, start_y),
-        )
+    if hasattr(mngr, "window"):
+        if platform.system() == "Windows":
+            wid = int(pix_x * 0.4)
+            hei = int(pix_y * 0.6)
+            start_x = int(pix_x * (0.1 + delta_x / 5))
+            start_y = int(pix_y * (0.1 + delta_y / 10))
+            mngr.window.wm_geometry(  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType] | Incomplete type hints in matplotlib
+                "{}x{}+{}+{}".format(wid, hei, start_x, start_y),
+            )
+        else:
+            wid = int(pix_x * 0.2)
+            hei = int(pix_y * 0.6)
+            start_x = int(pix_x * (0.1 + delta_x / 5))
+            start_y = int(pix_y * (0.1 + delta_y / 10))
+            mngr.window.wm_geometry(  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType] | Incomplete type hints in matplotlib
+                "{}x{}+{}+{}".format(wid, hei, start_x, start_y),
+            )
 
     # Set default colour map
     plt.jet()

--- a/src/rock_physics_open/ternary_plots/unconventionals_ternary.py
+++ b/src/rock_physics_open/ternary_plots/unconventionals_ternary.py
@@ -48,7 +48,10 @@ def run_ternary(
         lith_class, hard : (np.ndarray, np.ndarray).
         lith_class: lithology class [int], hardness [float].
     """
-    matplotlib.use("TkAgg")
+    if draw_figures:
+        matplotlib.use("TkAgg")
+    else:
+        matplotlib.use("Agg")
 
     lith_class = ternary_patches(
         quartz, carb, clay, kero, well_name, draw_figures=draw_figures

--- a/tests/shale_model_tests/test_ternary_plots.py
+++ b/tests/shale_model_tests/test_ternary_plots.py
@@ -1,6 +1,5 @@
 import os
 
-import pytest
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.snapshot_test_utilities import (
@@ -23,7 +22,6 @@ misc_log_type = "Vp"
 well_name = "35_11_15"
 
 
-@pytest.mark.use_graphics
 def test_ternary():
     args = run_ternary(
         quartz,


### PR DESCRIPTION
## Summary

Remove the `use_graphics` pytest marker and all related workarounds, so the ternary plot test runs on all platforms without requiring tkinter or a display.

Closes #5

## Changes

### `unconventionals_ternary.py`
- Guard `matplotlib.use("TkAgg")` behind `if draw_figures`, use `"Agg"` backend otherwise

### `ternary_plot_utilities.py`
- Add fallback resolution (1920×1080) when `xrandr` (Linux) or `system_profiler` (macOS) returns no output
- Guard `mngr.window.wm_geometry(...)` behind `hasattr(mngr, "window")` since the Agg backend's `FigureManagerBase` has no `window` attribute

### `test_ternary_plots.py`
- Remove `@pytest.mark.use_graphics` decorator and unused `pytest` import

### `pyproject.toml`
- Remove `use_graphics` marker definition

### `test.yaml`
- Collapse the two OS-conditional test steps into a single unconditional `uv run pytest`

### `CONTRIBUTING.md`
- Remove the `_tkinter` FAQ section (no longer needed)