### PR TITLE
docs: standardize docstrings to NumPy convention and add pydoclint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,13 @@ repos:
         pass_filenames: false
         files: .*\.py$
 
+      - id: pydoclint
+        name: "Python: docstring lint"
+        entry: uv run pydoclint src tests
+        language: system
+        pass_filenames: false
+        files: .*\.py$
+
       - id: basedpyright
         name: "Python: static type checking"
         entry: uv run basedpyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
     "matplotlib-stubs == 0.3.11",
     "pandas-stubs==3.0.0.260204",
     "pre-commit==4.5.1",
+    "pydoclint==0.8.3",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "ruff==0.15.8",
@@ -89,6 +90,7 @@ dev = [
 [tool.ruff]
 lint.select = [
     "C",       # Complexity
+    "D",       # Docstrings (pydocstyle)
     "E",       # Errors
     "F",       # Flake (unused variables etc.)
     "I",       # Imports
@@ -104,12 +106,27 @@ lint.select = [
 ]
 lint.ignore = [
     "C901", # Complex Code (too many branches/statements)
+    "D100", # Missing docstring in public module
+    "D101", # Missing docstring in public class
+    "D102", # Missing docstring in public method
+    "D103", # Missing docstring in public function
+    "D104", # Missing docstring in public package
+    "D105", # Missing docstring in magic method
+    "D203", # One blank line before class docstring (conflicts with D211)
+    "D213", # Multi-line docstring summary should start at the second line (conflicts with D212)
+    "D401", # First line should be in imperative mood
     "E501", # Line Too Long
 ]
 line-length = 88
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]
@@ -138,3 +155,12 @@ typeCheckingMode = "recommended"
 reportAny = false
 reportExplicitAny = false
 reportMissingTypeStubs = false
+
+[tool.pydoclint]
+style = "numpy"
+quiet = true
+skip-checking-raises = true
+check-style-mismatch = true
+arg-type-hints-in-docstring = false
+check-return-types = false
+check-yield-types = false

--- a/src/rock_physics_open/equinor_utilities/anisotropy.py
+++ b/src/rock_physics_open/equinor_utilities/anisotropy.py
@@ -26,17 +26,27 @@ def c_ij_2_c_factors(
     ]
     | None
 ):
-    """Transform a single stiffness tensor into components. VTI medium is assumed
+    """Transform a single stiffness tensor into components. VTI medium is assumed.
 
     Parameters
     ----------
-    cij : np.ndarray
+    cij
             A 6x6 matrix.
 
     Returns
     -------
-    tuple
-            (c11, c12, c13, c33, c44, c66).
+    c11
+            All 1-dimensional of same length.
+    c12
+            All 1-dimensional of same length.
+    c13
+            All 1-dimensional of same length.
+    c33
+            All 1-dimensional of same length.
+    c44
+            All 1-dimensional of same length.
+    c66
+            All 1-dimensional of same length.
     """
     if not isinstance(cij, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance]
         try:  # pyright: ignore[reportUnreachable]
@@ -70,13 +80,22 @@ def cfactors2cij(
 
     Parameters
     ----------
-    c11, c12, c13, c33, c44, c66 : np.ndarray
+    c11
+            All 1-dimensional of same length.
+    c12
+            All 1-dimensional of same length.
+    c13
+            All 1-dimensional of same length.
+    c33
+            All 1-dimensional of same length.
+    c44
+            All 1-dimensional of same length.
+    c66
             All 1-dimensional of same length.
 
     Returns
     -------
-    np.ndarray
-            A 6x6x(number of samples) stiffness tensor.
+    A 6x6x(number of samples) stiffness tensor.
     """
     c11, c12, c13, c33, c44, c66 = cast(
         list[npt.NDArray[np.float64]],
@@ -118,15 +137,23 @@ def c_ij_2_thomsen(
 
     Parameters
     ----------
-    c : np.ndarray
+    c
             A (log of or single instance of) 6x6 elastic tensor.
-    rho : np.ndarray
+    rho
             Density - log of same length as c.
 
     Returns
     -------
-    tuple
-            alpha, beta, gamma, delta, epsilon.
+    alpha
+            Thomsen's parameters.
+    beta
+            Thomsen's parameters.
+    gamma
+            Thomsen's parameters.
+    delta
+            Thomsen's parameters.
+    epsilon
+            Thomsen's parameters.
     """
     # C matrix should be 6x6
     if not isinstance(c, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance]
@@ -167,7 +194,9 @@ def thomsen_2_c_ij(
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
 ]:
-    """Elastic stiffness. Assumptions:
+    """Elastic stiffness.
+
+    Assumptions:
             Thomsen's parameters apply for weak anisotropy in a transversely isotropic medium:
 
             c11 c12 c13  0   0   0
@@ -186,15 +215,33 @@ def thomsen_2_c_ij(
 
     Parameters
     ----------
-    alpha, beta, gamma, delta, epsilon :
-            Thomsen's parameters.
-    rho :
-            Bulk density.
+    alpha
+        Thomsen's parameters.
+    beta
+        Thomsen's parameters.
+    gamma
+        Thomsen's parameters.
+    delta
+        Thomsen's parameters.
+    epsilon
+        Thomsen's parameters.
+    rho
+        Bulk density
 
     Returns
     -------
-    tuple
-            Elastic stiffness c11, c12, c13, c33, c44, c66.
+    c11
+        Elastic stiffness component c11.
+    c12
+        Elastic stiffness component c12.
+    c13
+        Elastic stiffness component c13.
+    c33
+        Elastic stiffness component c33.
+    c44
+        Elastic stiffness component c44.
+    c66
+        Elastic stiffness component c66.
     """
     alpha, beta, gamma, delta, epsilon = cast(
         list[npt.NDArray[np.float64]],

--- a/src/rock_physics_open/equinor_utilities/classification_functions/class_stats.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/class_stats.py
@@ -15,8 +15,9 @@ def gen_class_stats(
     npt.NDArray[np.int64],
 ]:
     """
-    Generate statistics - mean, covariance and prior probability - for each
-    class in the training data.	The observations are an n x m array, where n
+    Generate statistics - mean, covariance and prior probability - for each class in the training data.
+
+    The observations are an n x m array, where n
     is the number of observations and m is the number of variables. With p
     classes the returned mean value will be an array of dimension p x m,
     covariance m x m x p and the class_id and prior probability p length vector.
@@ -24,19 +25,30 @@ def gen_class_stats(
 
     Parameters
     ----------
-    obs : np.ndarray
+    obs
         An nxm array of data samples (observations).
-    class_val : np.ndarray
+    class_val
         n length vector with class ID of the observations. Assumed to
         be integer.
 
     Returns
     -------
-    tuple
-        class_mean, class_cov, prior_prob, class_counts, class_id : (np.ndarray, np.ndarray, np.ndarray, np.ndarray,
-        np.ndarray).
-    """
+    class_mean
+        p x m array of mean values per class.
+    class_cov
+        m x m x p array of covariance matrices per class.
+    prior_prob
+        Length-p vector of prior probabilities per class.
+    class_counts
+        Length-p vector with the number of observations per class.
+    class_id
+        Length-p vector of class labels.
 
+    Raises
+    ------
+    ValueError
+        If class values are not discrete numbers.
+    """
     n, m = obs.shape
     # Find number of classes. If class_val input is not integer, raise an exception
     if not (

--- a/src/rock_physics_open/equinor_utilities/classification_functions/lin_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/lin_class.py
@@ -15,24 +15,23 @@ def lin_class(
 
     Parameters
     ----------
-    obs : np.ndarray
+    obs
         An nxm array, where n is the number of samples and m is the number of features.
-    class_mean : np.ndarray
+    class_mean
         A pxm array, where p is the number of classes and m is the number of features.
-    class_id : np.ndarray
+    class_id
         A p length vector, where p is the number of classes, containing class_id (integer numbers).
-    thresh : float
+    thresh
         Unclassified threshold.
 
     Returns
     -------
-    tuple
-        lin_class_arr, lin_dist : (np.ndarray, np.ndarray).
-        lin_class_arr: nx1 vector. The classes are numbered according to class_id,
-        and unclassified samples (with distance greater than thresh) are set to 0,
-        lin_dist: nx1 vector with linear distance from the closest class centre to each sample.
+    lin_class_arr
+        nx1 vector. The classes are numbered according to class_id, and
+        unclassified samples (with distance greater than thresh) are set to 0.
+    lin_dist
+        nx1 vector with linear distance from the closest class centre to each sample.
     """
-
     # Find dimensions
     n = obs.shape[0]
     p = class_mean.shape[0]

--- a/src/rock_physics_open/equinor_utilities/classification_functions/mahal_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/mahal_class.py
@@ -12,33 +12,33 @@ def mahal_class(
     class_cov: npt.NDArray[np.float64],
     class_id: npt.NDArray[np.int64],
     thresh: float = np.inf,
-):
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Mahalanobis classification routine. All data points are assigned a class, unless a threshold is set
+    Mahalanobis classification routine. All data points are assigned a class, unless a threshold is set.
 
     Parameters
     ----------
-    obs : np.ndarray
+    obs
         An nxm array, where n is the number of samples and m is the number of variables.
-    class_mean : np.ndarray
+    class_mean
         A pxm array, where p is the number of classes and m is the number of variables.
-    class_cov : np.ndarray
+    class_cov
         A pxm array, where p is the number of classes and m is the number of variables.
-    class_id : np.ndarray
+    class_id
         A p length vector, where p is the number of classes, containing class_id (integer numbers).
-    thresh : float
+    thresh
         Unclassified threshold.
 
     Returns
     -------
-    tuple
-        mahal_class_arr, mahal_dist, mahal_pp : (np.ndarray, np.ndarray, np.ndarray).
-        mahal_class_arr: nx1 vector. The classes are numbered 1 to m, and unclassified samples (with distance
-        greater than thresh) are set to 0,
-        mahal_dist:	nx1 vector with mahalanobis distance from the closest class centre to sample,
-        mahal_pp: nx1 vector with posterior probability based on the distance to each class
+    mahal_class_arr
+        nx1 vector. The classes are numbered 1 to m, and unclassified samples
+        (with distance greater than thresh) are set to 0.
+    mahal_dist
+        nx1 vector with mahalanobis distance from the closest class centre to sample.
+    mahal_pp
+        nx1 vector with posterior probability based on the distance to each class.
     """
-
     # Find dimensions
     n = obs.shape[0]
     p = class_mean.shape[0]

--- a/src/rock_physics_open/equinor_utilities/classification_functions/norm_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/norm_class.py
@@ -13,37 +13,38 @@ def norm_class(
     thresh: float = np.inf,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Normal distribution classification routine. All data points are assigned a
-    class, unless a threshold is set. The "dist" calculated here is the quadratic
+    Normal distribution classification routine.
+
+    All data points are assigned a  class, unless a threshold is set. The "dist" calculated here is the quadratic
     discriminant function according to a Bayes classification. This is a negative
     number, and the closest class has the smallest absolute value.
 
     Parameters
     ----------
-    obs : np.ndarray
+    obs
         An nxm array, where n is the number of samples and m is the number of variables.
-    class_mean : np.ndarray
+    class_mean
         A pxm array, where p is the number of classes and m is the number of variables.
-    class_cov : np.ndarray
+    class_cov
         A pxm array, where p is the number of classes and m is the number of variables.
-    prior_prob : np.ndarray
+    prior_prob
         A p length vector, where p is the number of classes containing prior probabilities for each class.
-    class_id : np.ndarray
+    class_id
         A p length vector, where p is the number of classes, containing class_id (integer numbers).
-    thresh : float
+    thresh
         Unclassified threshold.
 
 
     Returns
-    --------
-    tuple
-        norm_class_id, norm_dist, norm_pp : (np.ndarray, np.ndarray, np.ndarray).
-        norm_class_id:	nx1 vector. The classes are numbered 1 to m, and unclassified
-        samples (with absolute distance greater than thresh) are set to 0,
-        norm_dist: nx1 vector with quadratic discriminant distance from the closest class centre to sample,
-        norm_pp: nx1 vector with posterior probability based on the distance to each class.
+    -------
+    norm_class_id
+        nx1 vector. The classes are numbered 1 to m, and unclassified samples
+        (with absolute distance greater than thresh) are set to 0.
+    norm_dist
+        nx1 vector with quadratic discriminant distance from the closest class centre to sample.
+    norm_pp
+        nx1 vector with posterior probability based on the distance to each class.
     """
-
     # Find dimensions
     n = obs.shape[0]
     p = class_mean.shape[0]

--- a/src/rock_physics_open/equinor_utilities/classification_functions/poly_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/poly_class.py
@@ -9,23 +9,27 @@ def poly_class(
     labels: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Points within the polygons are assigned to class labels. Point that do not
-    fall within any polygon are set to NULL_CLASS.
+    Points within the polygons are assigned to class labels.
+
+    Point that do not fall within any polygon are set to NULL_CLASS.
 
     Parameters
     ----------
-
-    train_data : np.ndarray
+    train_data
         Data points of two variables.
-    polygons : np.ndarray
+    polygons
         Vertices of polygons in two-dimensional space.
-    labels : np.ndarray
+    labels
         Class label for each polygon.
 
     Returns
     -------
-    np.ndarray
-        Class id.
+    Class id.
+
+    Raises
+    ------
+    ValueError
+        If number of labels are not matching number of polygons.
     """
     if len(labels) != len(polygons):
         raise ValueError("Number of labels are not matching number of polygons")

--- a/src/rock_physics_open/equinor_utilities/classification_functions/post_prob.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/post_prob.py
@@ -6,20 +6,18 @@ def posterior_probability(
     min_dist: npt.NDArray[np.float64], dist: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     """
-    Posterior probability, which is defined as the exponential of minimum distance divided by the sum of the
-    exponentials of distance to all classes.
+    Posterior probability, which is defined as the exponential of minimum distance divided by the sum of the exponentials of distance to all classes.
 
     Parameters
     ----------
-    min_dist : np.ndarray
+    min_dist
         Minimum class distance according to some metric.
-    dist : np.ndarray
+    dist
         All class distances, each class in a column in a two-dimensional array.
 
     Returns
     -------
-    np.ndarray
-        Posterior probability array.
+    Posterior probability array.
     """
     dist *= -1.0
     n_exp = np.exp(dist)

--- a/src/rock_physics_open/equinor_utilities/classification_functions/two_step_classification.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/two_step_classification.py
@@ -20,9 +20,9 @@ def gen_two_step_class_stats(
     npt.NDArray[np.float64],
 ]:
     """
-    The observations are an n x m array, where n
-    is the number of observations and m is the number of variables. With p
-    classes the returned mean value will be an array of dimension p x m,
+    The observations are an n x m array, where n is the number of observations and m is the number of variables.
+
+    With p classes the returned mean value will be an array of dimension p x m,
     covariance m x m x p and the class_id and prior probability p length vector.
 
     Generate statistics - mean, covariance and prior probability - for each
@@ -32,22 +32,27 @@ def gen_two_step_class_stats(
 
     Parameters
     ----------
-    obs : np.ndarray
+    obs
         An nxm array, where n is the number of samples and m is the number of variables.
-    class_val : np.ndarray
+    class_val
         A p length vector, where p is the number of classes, containing class_id (integer numbers).
-    thresh : float
+    thresh
         Unclassified threshold.
 
     Returns
     -------
-    tuple
-        (np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray).
-        class_mean, class_cov: statistics for each class after rejects;
-        prior_prob, class_counts: based on number of observations in each class,
-        find the prior probability of each class;
-        class_id: label for each class;
-        mahal_class_id: class id from mahalanobis classification.
+    class_mean
+        Mean values per class after rejects.
+    class_cov
+        Covariance matrices per class after rejects.
+    prior_prob
+        Prior probability per class based on observation counts after rejects.
+    class_counts
+        Number of observations per class after rejects.
+    class_id
+        Label for each class.
+    mahal_class_id
+        Class id from the initial Mahalanobis classification.
     """
     mean_class_id, class_cov, _, _, class_id = gen_class_stats(obs, class_val)
     mahal_class_id = mahal_class(obs, mean_class_id, class_cov, class_id, thresh)[0]

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/dict_to_float.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/dict_to_float.py
@@ -9,15 +9,14 @@ def dict_value_to_float(
 
     Parameters
     ----------
-    input_dict : dict
+    input_dict
         Input dictionary.
 
     Returns
     -------
-    dict
-        Output dictionary.
-    """
+    Output dictionary.
 
+    """
     for item in input_dict:
         if isinstance(input_dict[item], float):
             pass

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
@@ -9,24 +9,21 @@ import pandas as pd
 def dim_check_vector(
     args: list[Any] | tuple[Any, ...],
     force_type: np.dtype | None = ...,
-) -> list[npt.NDArray[Any] | pd.DataFrame]:
-    """Overload for when the input is a list or tuple."""
+) -> list[npt.NDArray[Any] | pd.DataFrame]: ...
 
 
 @overload
 def dim_check_vector(
     args: pd.DataFrame,
     force_type: np.dtype | None = ...,
-) -> pd.DataFrame:
-    """Overload for when the input is a pandas DataFrame."""
+) -> pd.DataFrame: ...
 
 
 @overload
 def dim_check_vector(
     args: npt.NDArray[Any],
     force_type: np.dtype | None = ...,
-) -> npt.NDArray[Any]:
-    """Overload for when the input is a numpy array."""
+) -> npt.NDArray[Any]: ...
 
 
 def dim_check_vector(
@@ -34,21 +31,26 @@ def dim_check_vector(
     force_type: np.dtype | None = None,
 ) -> npt.NDArray[Any] | pd.DataFrame | list[npt.NDArray[Any] | pd.DataFrame]:
     """
-    Check that all inputs are of the same (one-dimensional) size. Raise ValueError in case there are several lengths
-    present in the inputs. All inputs will be checked and possibly expanded to common length. Only the first dimension
+    Check that all inputs are of the same (one-dimensional) size.
+
+    All inputs will be checked and possibly expanded to common length. Only the first dimension
     is harmonised.
 
     Parameters
     ----------
-    args : list or tuple
+    args
         Input list or tuple of scalars, numpy arrays or pandas data frames of numerical or boolean type.
-    force_type : np.dtype
+    force_type
         Force all outputs to be of a specific dtype.
 
     Returns
     -------
-    output_args : list
-        List of inputs where all are of the same length.
+    List of inputs where all are of the same length.
+
+    Raises
+    ------
+    ValueError
+        If input type is not supported.
     """
     single_types = (np.ndarray, pd.DataFrame)
     iterable_types = (list, tuple)

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
@@ -16,8 +16,9 @@ def filter_input_log(
     positive: bool = True,
 ) -> tuple[npt.NDArray[np.bool_], list[npt.NDArray[Any] | pd.DataFrame]]:
     """
-    Check for valid input values in numpy arrays or pandas data frames. Default behaviour is to
-    identify missing values - assumed to be NaN and Inf. Other conditions
+    Check for valid input values in numpy arrays or pandas data frames.
+
+    Default behaviour is to identify missing values - assumed to be NaN and Inf. Other conditions
     can be stated in the key word arguments. Unknown conditions are ignored and a warning
     is issued. Run dim_check_vector to make sure that all inputs have the same length.
     Erroneous values in a sample in one log will remove the sample from all the logs.
@@ -25,23 +26,24 @@ def filter_input_log(
 
     Parameters
     ----------
-    args : list or tuple or np.ndarray or pd.DataFrame
+    args
         Inputs to be filtered, single array or dataframe or lists of arrays or data frames.
-    working_int : np.ndarray
+    working_int
         Valid positions are shown as values > 0.
-    negative : bool
+    negative
         Positive values are excluded (zero values are retained).
-    no_zero : bool
+    no_zero
         Zero values are excluded.
-    positive : bool
+    positive
         Negative values are excluded.
 
     Returns
     -------
-    tuple
-        idx, output_args : (np.ndarray, list)
-        indices of valid values [bool],
-        list of input arrays at valid indices.
+    idx
+        Boolean indices of valid values.
+    output_args
+        List of input arrays filtered to valid indices.
+
     """
     type_error = "filter_input_log: unknown input data type: {}".format(type(args))
     size_error = "filter_input_log: inputs of different length"

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
@@ -13,23 +13,21 @@ def filter_output(
     | pd.DataFrame,
 ) -> list[npt.NDArray[Any] | pd.DataFrame]:
     """
-    Function to restore outputs from a plugin to original length and
-    with values at correct positions. The logs are assumed to go through
-    matching input filtering done by gen_utilities.filter_input_log earlier.
+    Function to restore outputs from a plugin to original length and with values at correct positions.
+
+    The logs are assumed to go through matching input filtering done by gen_utilities.filter_input_log earlier.
 
     Parameters
     ----------
-    idx_inp: np.ndarray
-        boolean array which is True at locations to be filled, length idx_inp is returned length of
-        arrays or data frames.
-    inp_log: tuple or list or np.ndarray or pd.DataFrame
-        input numpy array(s) or pandas data frame(s), in list or tuple that are to be expanded to original
-        length.
+    idx_inp
+        boolean array which is True at locations to be filled, length idx_inp is returned length of arrays or data frames.
+    inp_log
+        input numpy array(s) or pandas data frame(s), in list or tuple that are to be expanded to original length.
 
     Returns
     -------
-    return_logs : list
-        Expanded inputs.
+    Expanded inputs.
+
     """
 
     def _expand_array(

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/base_pressure_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/base_pressure_model.py
@@ -16,19 +16,16 @@ class BasePressureModel(ABC):
 
     Input validation is delegated to concrete implementations since
     each model has different column requirements.
+
+    Parameters
+    ----------
+    model_max_pressure
+        Maximum pressure for predict_max method. Required for predict_max to work.
+    description
+        Human-readable description of the model instance.
     """
 
     def __init__(self, model_max_pressure: float | None = None, description: str = ""):
-        """
-        Initialize base pressure model.
-
-        Parameters
-        ----------
-        model_max_pressure : float | None
-            Maximum pressure for predict_max method. Required for predict_max to work.
-        description : str
-            Human-readable description of the model instance.
-        """
         self._model_max_pressure: float | None = model_max_pressure
         self._description: str = description
 
@@ -48,13 +45,12 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array with pressure columns and other model-specific parameters.
 
         Returns
         -------
-        np.ndarray
-            Differential change values.
+        Differential change values.
         """
         arr = self.validate_input(inp_arr)
         return self.predict_abs(arr, case="depleted") - self.predict_abs(
@@ -67,13 +63,12 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array where last column (depleted pressure) will be replaced.
 
         Returns
         -------
-        np.ndarray
-            Values at model_max_pressure minus values at in_situ pressure.
+        Values at model_max_pressure minus values at in_situ pressure.
 
         Raises
         ------
@@ -97,13 +92,12 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array to validate.
 
         Returns
         -------
-        np.ndarray
-            Validated input array.
+        Validated input array.
 
         Raises
         ------
@@ -118,15 +112,14 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Validated input array.
-        case : str
+        case
             Either "in_situ" or "depleted" to specify which pressure to use.
 
         Returns
         -------
-        np.ndarray
-            Absolute predicted values.
+        Absolute predicted values.
         """
 
     @abstractmethod
@@ -136,8 +129,7 @@ class BasePressureModel(ABC):
 
         Returns
         -------
-        dict[str, Any]
-            Dictionary containing all model parameters.
+        Dictionary containing all model parameters.
         """
 
     def save(self, file: str | bytes) -> None:
@@ -146,7 +138,7 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        file : str | bytes
+        file
             File path for saving.
         """
         with open(file, "wb") as f_out:
@@ -160,11 +152,10 @@ class BasePressureModel(ABC):
 
         Parameters
         ----------
-        file : str | bytes
+        file
             File path for loading.
 
         Returns
         -------
-        BasePressureModel
-            Loaded model instance.
+        Loaded model instance.
         """

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/dummy_vars.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/dummy_vars.py
@@ -13,25 +13,28 @@ def generate_dummy_vars(
     ohe: OneHotEncoder | None = None,
 ) -> tuple[npt.NDArray[np.float64], int, npt.NDArray[np.str_]]:
     """
-    From categorical variables generate a one-hot-encoder, i.e. each value in the categorical variable becomes a binary
-    variable. See sklearn.preprocessing.OneHotEncoder.
+    From categorical variables generate a one-hot-encoder, i.e. each value in the categorical variable becomes a binary variable.
+
+    See sklearn.preprocessing.OneHotEncoder.
 
     Parameters
     ----------
-    inp_frame : pd.DataFrame
+    inp_frame
         Input data containing categorical variables.
-    class_var : str
+    class_var
         Name of categorical variable.
-    ohe : preprocessing.OneHotEncoder
+    ohe
         One-hot-encoder object.
 
     Returns
     -------
-    dum_features, no_dummy_cols, dum_var_names : (np.ndarray, int, np.ndarray)
-        dum_features: 2D array with transformed dummy variables, no_dummy_cols: number of columns in returned array,
-        dum_var_names: automatically generated feature names.
+    dum_features
+        2D array with transformed dummy variables.
+    no_dummy_cols
+        Number of columns in the returned array.
+    dum_var_names
+        Automatically generated feature names.
     """
-
     if is_numeric_dtype(inp_frame[class_var]):
         # Make sure that the chosen indicator variable contains discrete values
         inp_frame = inp_frame.astype({class_var: "int32"})

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
@@ -16,6 +16,17 @@ class ExponentialPressureModel(BasePressureModel):
     where v0 is reference velocity, p is pressure, a and b are model parameters.
 
     Input format (n,3): [velocity, p_eff_in_situ, p_eff_depleted]
+
+    Parameters
+    ----------
+    a_factor
+        Exponential amplitude parameter [unitless].
+    b_factor
+        Exponential decay parameter [Pa].
+    model_max_pressure
+        Maximum pressure for predict_max method [Pa].
+    description
+        Model description.
     """
 
     def __init__(
@@ -25,20 +36,6 @@ class ExponentialPressureModel(BasePressureModel):
         model_max_pressure: float | None = None,
         description: str = "",
     ):
-        """
-        Initialize exponential pressure model.
-
-        Parameters
-        ----------
-        a_factor : float
-            Exponential amplitude parameter [unitless].
-        b_factor : float
-            Exponential decay parameter [Pa].
-        model_max_pressure : float | None
-            Maximum pressure for predict_max method [Pa].
-        description : str
-            Model description.
-        """
         super().__init__(model_max_pressure, description)
         self._a_factor = a_factor
         self._b_factor = b_factor
@@ -60,13 +57,12 @@ class ExponentialPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array to validate.
 
         Returns
         -------
-        np.ndarray
-            Validated input array.
+        Validated input array.
 
         Raises
         ------
@@ -88,15 +84,14 @@ class ExponentialPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Validated input array (n,3).
-        case : str
+        case
             Pressure case: "in_situ" or "depleted".
 
         Returns
         -------
-        np.ndarray
-            Velocity values [m/s].
+        Velocity values [m/s].
         """
         arr = self.validate_input(inp_arr)
 

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/import_ml_models.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/import_ml_models.py
@@ -22,22 +22,35 @@ def import_model(
     str | list[str],
 ]:
     """
-    Utility to import a pickled dict containing information needed to run a classification or regression based on
-    a calibrated model.
+    Utility to import a pickled dict containing information needed to run a classification or regression based on a calibrated model.
 
     Parameters
     ----------
-    model_file_name : str
+    model_file_name
         Full name including path for model file.
 
     Returns
     -------
-    models, scaler, ohe, label_var, label_units, feature_var, cat_var : Any
-        models: various regression or classification models from e.g. sklearn or tensorflow keras, scaler: preprocessing
-        Robust Scaler, label_var: name(s) of label variable(s), label_unit: unit(s) of label variable(s), cat_var:
-        categorical variables that should be encoded with one-hot-encoder.
-    """
+    models
+        Regression or classification model (e.g. from sklearn or keras).
+    scaler
+        Preprocessing Robust Scaler.
+    ohe
+        One-hot encoder for categorical variables, if any.
+    label_var
+        Name(s) of label variable(s).
+    label_unit
+        Unit(s) of label variable(s).
+    feature_var
+        Names of feature variables.
+    cat_var
+        Categorical variables encoded with the one-hot-encoder.
 
+    Raises
+    ------
+    ValueError
+        If model type is unknown.
+    """
     with open(model_file_name, "rb") as fin, warnings.catch_warnings():
         # 11.04.2021 HFLE: There is an issue that is not connected to the local function, in that a warning is issued
         # when the model is loaded, claiming that it is of an older version. This is debugged in detail, and the model

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
@@ -16,6 +16,16 @@ class PolynomialPressureModel(BasePressureModel):
     where P(p) is a polynomial function with specified coefficients.
 
     Input format (n,3): [velocity, p_eff_in_situ, p_eff_depleted]
+
+    Parameters
+    ----------
+    weights
+        Polynomial coefficients [unitless]. First element is constant term,
+        second is linear coefficient, etc.
+    model_max_pressure
+        Maximum pressure for predict_max method [Pa].
+    description
+        Model description.
     """
 
     def __init__(
@@ -24,19 +34,6 @@ class PolynomialPressureModel(BasePressureModel):
         model_max_pressure: float | None = None,
         description: str = "",
     ):
-        """
-        Initialize polynomial pressure model.
-
-        Parameters
-        ----------
-        weights : list[float]
-            Polynomial coefficients [unitless]. First element is constant term,
-            second is linear coefficient, etc.
-        model_max_pressure : float | None
-            Maximum pressure for predict_max method [Pa].
-        description : str
-            Model description.
-        """
         super().__init__(model_max_pressure, description)
         self._weights = weights
 
@@ -52,13 +49,12 @@ class PolynomialPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array to validate.
 
         Returns
         -------
-        np.ndarray
-            Validated input array.
+        Validated input array.
 
         Raises
         ------
@@ -80,15 +76,19 @@ class PolynomialPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Validated input array (n,3).
-        case : str
+        case
             Pressure case: "in_situ" or "depleted".
 
         Returns
         -------
-        np.ndarray
-            Velocity values [m/s].
+        Velocity values [m/s].
+
+        Raises
+        ------
+        ValueError
+            If field "weights" is not set.
         """
         arr = self.validate_input(inp_arr)
 

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/run_regression.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/run_regression.py
@@ -172,21 +172,19 @@ def run_regression(
 
     Parameters
     ----------
-    inp_df : pd.DataFrame
+    inp_df
         Input logs required for the regression.
-    first_model_file_name : str
+    first_model_file_name
         Full file name for vp model.
-    second_model_file_name : str
+    second_model_file_name
         Full file name for vs model.
-    model_dir : str | None
+    model_dir
         Directory.
 
     Returns
     -------
-    vp, vs : pd.DataFrame
-        Estimated vp and vs as series in Pandas DataFrame.
+    Estimated vp and vs as series in Pandas DataFrame.
     """
-
     (
         regression_model,
         scaler_obj,

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
@@ -20,6 +20,27 @@ class SigmoidalPressureModel(BasePressureModel):
     The model applies two sigmoid transformations:
     1. Porosity -> velocity amplitude using phi_model parameters
     2. Effective pressure -> velocity using p_eff_model parameters and amplitude
+
+    Parameters
+    ----------
+    phi_amplitude
+        Amplitude parameter for porosity sigmoid [m/s].
+    phi_median_point
+        Median point for porosity sigmoid [fraction].
+    phi_x_scaling
+        X-scaling parameter for porosity sigmoid [unitless].
+    phi_bias
+        Bias parameter for porosity sigmoid [m/s].
+    p_eff_median_point
+        Median point for pressure sigmoid [Pa].
+    p_eff_x_scaling
+        X-scaling parameter for pressure sigmoid [1/Pa].
+    p_eff_bias
+        Bias parameter for pressure sigmoid [m/s].
+    model_max_pressure
+        Maximum pressure for predict_max method [Pa].
+    description
+        Model description.
     """
 
     def __init__(
@@ -34,30 +55,6 @@ class SigmoidalPressureModel(BasePressureModel):
         model_max_pressure: float | None = None,
         description: str = "",
     ):
-        """
-        Initialize sigmoidal pressure model.
-
-        Parameters
-        ----------
-        phi_amplitude : float
-            Amplitude parameter for porosity sigmoid [m/s].
-        phi_median_point : float
-            Median point for porosity sigmoid [fraction].
-        phi_x_scaling : float
-            X-scaling parameter for porosity sigmoid [unitless].
-        phi_bias : float
-            Bias parameter for porosity sigmoid [m/s].
-        p_eff_median_point : float
-            Median point for pressure sigmoid [Pa].
-        p_eff_x_scaling : float
-            X-scaling parameter for pressure sigmoid [1/Pa].
-        p_eff_bias : float
-            Bias parameter for pressure sigmoid [m/s].
-        model_max_pressure : float | None
-            Maximum pressure for predict_max method [Pa].
-        description : str
-            Model description.
-        """
         super().__init__(model_max_pressure, description)
         # Porosity model parameters
         self._phi_amplitude = phi_amplitude
@@ -111,13 +108,12 @@ class SigmoidalPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Input array to validate.
 
         Returns
         -------
-        np.ndarray
-            Validated input array.
+        Validated input array.
 
         Raises
         ------
@@ -138,13 +134,12 @@ class SigmoidalPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        phi : np.ndarray
+        phi
             Porosity values [fraction].
 
         Returns
         -------
-        np.ndarray
-            Velocity amplitude values [m/s].
+        Velocity amplitude values [m/s].
         """
         return (
             self._phi_amplitude
@@ -158,15 +153,14 @@ class SigmoidalPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        p_eff : np.ndarray
+        p_eff
             Effective pressure values [Pa].
-        amplitude : np.ndarray
+        amplitude
             Velocity amplitude values [m/s].
 
         Returns
         -------
-        np.ndarray
-            Velocity values [m/s].
+        Velocity values [m/s].
         """
         return (
             amplitude
@@ -181,15 +175,14 @@ class SigmoidalPressureModel(BasePressureModel):
 
         Parameters
         ----------
-        inp_arr : np.ndarray
+        inp_arr
             Validated input array (n,3).
-        case : str
+        case
             Pressure case: "in_situ" or "depleted".
 
         Returns
         -------
-        np.ndarray
-            Velocity values [m/s].
+        Velocity values [m/s].
         """
         arr = self.validate_input(inp_arr)
 

--- a/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
+++ b/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
@@ -21,33 +21,41 @@ def gen_opt_routine(
     **opt_kwargs: Any,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    This function is a lean method for running optimisation with the given opt_function in curve_fit. Predicted values,
-    residuals to the observed values and optimal parameters are returned.
+    Run optimisation with the given opt_function in curve_fit.
+
+    Predicted values, residuals to the observed values and optimal parameters are returned.
 
     Parameters
     ----------
-    opt_function : callable
+    opt_function
         function to optimise
-    x_data_orig : np.ndarray
+    x_data_orig
         input data to the function - independent variables
-    y_data : np.ndarray
+    y_data
         results that the optimisation should match - dependent variables
-    x_init : np.ndarray
+    x_init
         initial guess for parameters
-    low_bound : np.ndarray
+    low_bound
         parameter low bound
-    high_bound : np.ndarray
+    high_bound
         parameter high bound
-    opt_kwargs : dict
+    **opt_kwargs
         optional meta-parameters to the optimisation function
 
     Returns
     -------
-    tuple
-        y_pred, y_res, opt_params : (np.ndarray, np.ndarray, np.ndarray).
-        y_pred : predicted values,
-        y_res : residual values,
-        opt_params : optimal model parameters.
+    y_pred
+        Predicted values.
+    y_res
+        Residual values (``y_pred - y_data``).
+    opt_params
+        Optimal model parameters.
+
+    Raises
+    ------
+    ValueError
+        Re-raised from :func:`scipy.optimize.curve_fit` when the optimisation
+        step fails.
     """
     try:
         opt_params, _ = cast(
@@ -89,19 +97,18 @@ def gen_mod_routine(
 
     Parameters
     ----------
-    opt_function : callable
+    opt_function
         Function to optimise.
-    xdata_orig : np.ndarray
+    xdata_orig
         Input data to the function - independent variables.
-    ydata_shape : (int, int)
+    ydata_shape
         Shape of y_data.
-    opt_params : np.ndarray
+    opt_params
         Optimal model parameters.
 
     Returns
     -------
-    np.ndarray
-        Predicted values.
+    Predicted values.
     """
     # Estimation of values
     return np.reshape(opt_function(xdata_orig, *opt_params), ydata_shape, order="F")
@@ -115,28 +122,32 @@ def gen_sub_routine(
     opt_params: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """General substitution function based on a calibrated/optimised model and with two sets of input parameters.
+
     The substituted values are calculated as the original observations plus the difference of the two modelling
     steps.
 
     Parameters
     ----------
-    opt_function : callable
+    opt_function
         Function to optimise.
-    xdata_orig : np.ndarray
+    xdata_orig
         Input data to the function step 1 - independent variables.
-    xdata_new : np.ndarray
+    xdata_new
         Input data to the function step 2 - independent variables.
-    ydata : np.ndarray
+    ydata
         Original observed values step 1.
-    opt_params : np.ndarray
+    opt_params
         Set of optimal parameters to model.
 
     Returns
     -------
-    tuple
-        y_final, y_pred, y_res : (np.ndarray, np.ndarray, np.ndarray).
-        Original observed data + difference in estimation between steps 0 and 1, y_pred - modelled data,
-        y_res - residuals, opt_params - best parameter setting.
+    y_final
+        Original observed data plus the difference in estimation between the
+        two modelling steps.
+    y_pred
+        Modelled data for the original inputs.
+    y_res
+        Residuals of the initial prediction (``y_pred - ydata``).
     """
     # Estimation of initial values
     y_pred = np.reshape(opt_function(xdata_orig, *opt_params), ydata.shape, order="F")
@@ -226,18 +237,17 @@ def save_opt_params(
     well_name: str = "Unknown well",
 ) -> None:
     """
-    Utility to save optimal parameters as a pickle file in a more readable format so that the optimisation method can be
-    recognised.
+    Utility to save optimal parameters as a pickle file in a more readable format so that the optimisation method can be recognised.
 
     Parameters
     ----------
-    opt_type : str
+    opt_type
         String defining optimisation type.
-    opt_params : np.ndarray
+    opt_params
         Numpy array with parameters from optimisation.
-    file_name : str, optional
+    file_name
         File to save results to, by default 'opt_params.pkl'.
-    well_name : str, optional
+    well_name
         Name of the well which is used in optimisation, by default 'Unknown well'.
 
     Raises
@@ -312,10 +322,15 @@ def opt_param_info() -> tuple[
     ParameterTranslationDict, ValueTranslationDict, TypeTranslationDict
 ]:
     """Hard coded dictionaries returned.
+
     Returns
     -------
-    tuple
-        parameter_translation_dict, value_translation_dict, type_translation_dict.
+    parameter_translation_dict
+        Mapping from optimisation parameter keys to human-readable descriptions.
+    value_translation_dict
+        Mapping from parameter keys to default numerical values.
+    type_translation_dict
+        Mapping from optimisation type codes to descriptive names.
     """
     parameter_translation_dict: ParameterTranslationDict = {
         "opt_ver": "Optimisation version",
@@ -373,13 +388,17 @@ def load_opt_params(
 
     Parameters
     ----------
-    file_name : str
+    file_name
         Input file name including path.
 
     Returns
     -------
-    tuple
-        opt_type: model type, no_sets: number of inclusion sets, opt_param: with all parameters for model.
+    opt_type
+        Optimisation model type.
+    opt_param
+        Array of optimal parameters for the model.
+    opt_dict
+        Full dictionary of optimisation results as loaded from the file.
     """
     with open(file_name, "rb") as fin:
         param_dict: OptParamsDict = pickle.load(fin)
@@ -401,14 +420,16 @@ def opt_param_to_ascii(
 
     Parameters
     ----------
-    in_file : str
+    in_file
         File name for stored optimised parameters.
-    display_results : bool
+    display_results
         Display results on screen, default True.
-    out_file : str or None
+    out_file
         Optional store optimised parameters in ascii file.
-    well_name : str
+    well_name
         Optional name of the well that is used in optimisation.
+    **kwargs
+        Keyword arguments for tkinter.
     """
     with open(in_file, "rb") as f_in:
         param_dict = pickle.load(f_in)

--- a/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/snapshots.py
+++ b/src/rock_physics_open/equinor_utilities/snapshot_test_utilities/snapshots.py
@@ -44,17 +44,24 @@ def get_snapshot_name(
     include_snapshot_dir: bool = True,
 ) -> str:
     """
+    Generate a snapshot name from the call stack.
+
     Parameters
     ----------
-    step: number of steps in the trace to collect information from
-    include_snapshot_dir: absolute directory name included in snapshot name
-    include_filename: whether to include filename in snapshot name
-    include_function_name: whether to include function name in snapshot name
-    include_extension: whether to include extension in snapshot name
+    step
+        Number of steps in the trace to collect information from.
+    include_filename
+        Whether to include filename in snapshot name.
+    include_function_name
+        Whether to include function name in snapshot name.
+    include_extension
+        Whether to include extension in snapshot name.
+    include_snapshot_dir
+        Absolute directory name included in snapshot name.
 
     Returns
     -------
-    name of snapshot file
+    Name of snapshot file.
     """
     trace = inspect.stack()
     for frame in trace[step:]:
@@ -74,6 +81,24 @@ def get_snapshot_name(
 
 def store_snapshot(snapshot_name: str, *args: np.ndarray) -> bool:
     """
+    Store arrays as a snapshot.
+
+    Parameters
+    ----------
+    snapshot_name
+        Name/path of the snapshot file.
+    *args
+        Arrays to store.
+
+    Returns
+    -------
+    True if snapshot was stored successfully.
+
+    Raises
+    ------
+    IOError
+        If snapshot could not be stored.
+
     Examples
     --------
     In case there are multiple arrays to store:

--- a/src/rock_physics_open/equinor_utilities/std_functions/backus_ave.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/backus_ave.py
@@ -18,34 +18,40 @@ def backus_average(
     npt.NDArray[np.float64],
 ]:
     """
-    Backus average for a combination of two phases. The individual phases are isotropic
-    but the resulting effective medium is not.
+    Backus average for a combination of two phases.
+
+    The individual phases are isotropic but the resulting effective medium is not.
 
     Parameters
     ----------
-    vp1 : np.ndarray
+    vp1
         Pressure wave velocity for phase 1 [m/s].
-    vs1 : np.ndarray
+    vs1
         Shear wave velocity for phase 1 [m/s].
-    rho1 : np.ndarray
+    rho1
         Density for phase 1 [kg/m^3].
-    vp2 : np.ndarray
+    vp2
         Pressure wave velocity for phase 2 [m/s].
-    vs2 : np.ndarray
+    vs2
         Shear wave velocity for phase 2 [m/s].
-    rho2 : np.ndarray
+    rho2
         Density for phase 2 [kg/m^3].
-    f1 : np.ndarray
-        Fraction of phase 1.
+    f1
+        Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        vpv, vsv, vph, vsh, rho : np.ndarray
-        vpv: vertical pressure velocity, vsv: vertical shear velocity, vph: horizontal pressure velocity,
-        vsh: horizontal shear velocity, rho: density.
+    vpv
+        Vertical pressure velocity.
+    vsv
+        Vertical shear velocity.
+    vph
+        Horizontal pressure velocity.
+    vsh
+        Horizontal shear velocity.
+    rho
+        Effective density.
     """
-
     a = (
         4 * f1 * rho1 * vs1**2 * (1 - vs1**2 / vp1**2)
         + 4 * (1 - f1) * rho2 * vs2**2 * (1 - (vs2 / vp2) ** 2)

--- a/src/rock_physics_open/equinor_utilities/std_functions/dvorkin_nur.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/dvorkin_nur.py
@@ -17,28 +17,29 @@ def dvorkin_contact_cement(
 
     Parameters
     ----------
-    frac_cem : np.ndarray | float
+    frac_cem
         Cement fraction of volume [ratio].
-    por0_sst : np.ndarray | float
+    por0_sst
         Critical porosity of sand [ratio].
-    mu0_sst : np.ndarray
+    mu0_sst
         Mineral shear modulus of sand [Pa].
-    k0_sst : np.ndarray
+    k0_sst
         Mineral bulk modulus of sand [Pa].
-    mu0_cem : np.ndarray
+    mu0_cem
         Mineral shear modulus of cement [Pa].
-    k0_cem : np.ndarray
+    k0_cem
         Mineral bulk modulus of cement [Pa].
-    vs_red : np.ndarray | float
+    vs_red
         Shear modulus reduction factor [ratio].
-    c : np.ndarray | float
+    c
         Coordination number (grain contacts per grain) [unitless].
 
     Returns
     -------
-    tuple
-        k_cc, mu_cc : numpy.ndarray.
-        k_cc: bulk modulus [Pa], mu_cc: shear modulus [Pa].
+    k_cc
+        Bulk modulus [Pa].
+    mu_cc
+        Shear modulus [Pa].
     """
     alpha = (2 * frac_cem / (3 * (1 - por0_sst))) ** 0.5
     poiss = (3 * k0_sst - 2 * mu0_sst) / (2 * (3 * k0_sst + mu0_sst))

--- a/src/rock_physics_open/equinor_utilities/std_functions/gassmann.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/gassmann.py
@@ -18,19 +18,18 @@ def gassmann(
 
     Parameters
     ----------
-    k_dry : np.ndarray
+    k_dry
         Dry rock bulk modulus [Pa].
-    por : np.ndarray
+    por
         Porosity [fraction].
-    k_fl : np.ndarray
-        Fluid bulk modulus.
-    k_min : np.ndarray
+    k_fl
+        Fluid bulk modulus [Pa].
+    k_min
         Mineral bulk modulus [Pa].
 
     Returns
     -------
-    np.ndarray
-        k_sat: bulk modulus for saturated rock [Pa]
+    Bulk modulus for saturated rock [Pa].
     """
     k_dry, por, k_fl, k_min = cast(
         list[npt.NDArray[np.float64]],
@@ -60,25 +59,24 @@ def gassmann2(
     k_min: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Fluid substitution by Gassmann method with substitution of one fluid to another
+    Fluid substitution by Gassmann method with substitution of one fluid to another.
 
     Parameters
     ----------
-    k_sat_1 : np.ndarray
+    k_sat_1
         bulk modulus for saturated rock with original fluid [Pa]
-    k_fl_1 : np.ndarray
+    k_fl_1
         bulk modulus for original fluid [Pa]
-    k_fl_2 : np.ndarray
+    k_fl_2
         bulk modulus for replaced fluid [Pa]
-    por : np.ndarray
+    por
         porosity of rock [fraction]
-    k_min : np.ndarray
+    k_min
         mineral bulk modulus of rock [Pa]
 
     Returns
     -------
-    np.ndarray
-        k_sat_2: bulk modulus of rock saturated with replaced fluid [Pa]
+    Bulk modulus of rock saturated with replaced fluid [Pa].
     """
     k_sat_1, k_fl_1, k_fl_2, por, k_min = cast(
         list[npt.NDArray[np.float64]],
@@ -120,23 +118,22 @@ def gassmann_dry(
     k_min: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Dry rock properties of saturated rock by Gassmann equation
+    Dry rock properties of saturated rock by Gassmann equation.
 
     Parameters
     ----------
-    k_sat : np.ndarray
+    k_sat
         saturated rock bulk modulus [Pa]
-    por : np.ndarray
+    por
         porosity of rock [fraction]
-    k_fl : np.ndarray
+    k_fl
         bulk modulus of fluid [Pa]
-    k_min : np.ndarray
+    k_min
         bulk modulus of mineral [Pa]
 
     Returns
     -------
-    np.ndarray
-        k_dry: dry rock bulk modulus [Pa]
+    Dry rock bulk modulus [Pa].
     """
     k_sat, por, k_fl, k_min = cast(
         list[npt.NDArray[np.float64]],

--- a/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
@@ -14,26 +14,27 @@ def hashin_shtrikman(
     f: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Hashin-Sktrikman upper or lower according to ordering of phases.
+    Hashin-Shtrikman upper or lower according to ordering of phases.
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f : np.ndarray
+    f
         Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray.
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa].
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     k = k1 + (1 - f) * (k2 - k1) / (1 + (k2 - k1) * f * (k1 + 4 / 3 * mu1) ** -1)
     mu = mu1 + (1 - f) * (mu2 - mu1) / (
@@ -55,22 +56,23 @@ def hashin_shtrikman_average(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f : np.ndarray
+    f
         Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        k_av, mu_av : np.ndarray.
-        k_av: effective bulk modulus [Pa], mu_av: effective shear modulus [Pa]
+    k_av
+        Effective bulk modulus [Pa].
+    mu_av
+        Effective shear modulus [Pa].
     """
     k_hs1, mu_hs1 = hashin_shtrikman(k1, mu1, k2, mu2, f)
     k_hs2, mu_hs2 = hashin_shtrikman(k2, mu2, k1, mu1, 1 - f)
@@ -90,31 +92,33 @@ def hashin_shtrikman_walpole(
     bound: Literal["upper", "lower"] = "lower",
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Hashin-Shtrikman upper bound is obtained when the stiffest material is
-    termed 1 and vice versa for lower bound. Tricky in cases like Quartz -
-    Calcite where the K and Mu have opposed values. HS - Walpole is
-    generalised to regard highest and lowest values in each case. The default
-    is to generate lower bound.
+    Hashin-Shtrikman upper bound is obtained when the stiffest material is termed 1 and vice versa for lower bound.
+
+    Tricky in cases like Quartz - Calcite where the K and Mu have opposed values.
+    HS - Walpole is generalised to regard highest and lowest values in each case. The default is to generate lower bound.
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f1 : np.ndarray or float
+    f1
         Fraction of phase 1 [fraction].
-    bound: str
-        'upper' or 'lower' selection of upper of lower bound of effective medium.
+    bound
+        Upper or lower bound of effective medium. Default is 'lower'.
+
     Returns
     -------
-    tuple
-        k, mu : np.ndarray.
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa].
+    k
+        effective bulk modulus [Pa]
+    mu
+        effective shear modulus [Pa].
+
     """
     k1, mu1, k2, mu2, f1 = cast(
         list[npt.NDArray[np.float64]],
@@ -172,16 +176,18 @@ def multi_hashin_shtrikman(
 
     Parameters
     ----------
-    coeffs : np.ndarray
+    *coeffs
         Triplets of vectors with k (bulk modulus [Pa]), mu (shear modulus [Pa]) and fraction for each mineral.
-    mode : str
+    mode
         'average', 'upper' or 'lower'.
 
     Returns
     -------
-    tuple
-        k_hs, mu_hs : np.ndarray.
-        k_hs, mu_hs - bulk modulus and shear modulus for effective medium [Pa].
+    k_hs
+        Bulk modulus for effective medium [Pa].
+    mu_hs
+        Shear modulus for effective medium [Pa].
+
     """
     if not len(coeffs) % 3 == 0:
         raise ValueError(

--- a/src/rock_physics_open/equinor_utilities/std_functions/hertz_mindlin.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/hertz_mindlin.py
@@ -15,15 +15,15 @@ def hertz_mindlin(
 
     Parameters
     ----------
-    k : np.ndarray
+    k
         Bulk modulus of grain mineral [Pa].
-    mu : np.ndarray
+    mu
         Shear modulus of grain mineral [Pa].
-    phi_c : np.ndarray
+    phi_c
         Critical porosity [fraction].
-    p : np.ndarray
+    p
         Effective pressure = lithostatic pressure - hydrostatic pressure [Pa].
-    shear_red : float or np.ndarray
+    shear_red
         Reduced shear factor, if set to 1.0, calculation reduces to standard Hertz-Mindlin equation.
     coord
         coordination number, i.e. the number of grain contacts per grain. If not provided a porosity based
@@ -31,10 +31,10 @@ def hertz_mindlin(
 
     Returns
     -------
-    tuple
-        k_dry, mu_dry : np.ndarray.
-        k_dry:	Bulk modulus [Pa] at effective pressure p,
-        mu_dry:	Shear modulus [Pa] at effective pressure p.
+    k_dry
+        Bulk modulus [Pa] at effective pressure p.
+    mu_dry
+        Shear modulus [Pa] at effective pressure p.
     """
     n = 25.98805 * phi_c**2 - 43.7622 * phi_c + 21.6719 if coord is None else coord
 

--- a/src/rock_physics_open/equinor_utilities/std_functions/moduli_velocity.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/moduli_velocity.py
@@ -1,33 +1,33 @@
-from typing import TypeVar, cast
+from typing import cast
 
 import numpy as np
-import numpy.typing as npt
 
-_T = TypeVar("_T", npt.NDArray[np.float64], float)
+from rock_physics_open.equinor_utilities.various_utilities.types import ArrayAnyDOrFloat
 
 
 def moduli(
-    vp: _T,
-    vs: _T,
-    rhob: _T,
-) -> tuple[_T, _T]:
+    vp: ArrayAnyDOrFloat,
+    vs: ArrayAnyDOrFloat,
+    rhob: ArrayAnyDOrFloat,
+) -> tuple[ArrayAnyDOrFloat, ArrayAnyDOrFloat]:
     """
     Calculate isotropic moduli from velocity and density.
 
     Parameters
     ----------
-    vp : np.ndarray or float
+    vp
         Pressure wave velocity [m/s].
-    vs : np.ndarray or float
+    vs
         Shear wave velocity [m/s].
-    rhob : np.ndarray or float
+    rhob
         Bulk density [kg/m^3].
 
     Returns
     -------
-    tuple
-        k, mu : (np.ndarray, np.ndarray) or (float, float).
-        k: bulk modulus [Pa], mu: shear modulus [Pa].
+    k
+        Bulk modulus [Pa].
+    mu
+        Shear modulus [Pa].
     """
     mu = vs**2 * rhob
     k = vp**2 * rhob - 4 / 3 * mu
@@ -36,34 +36,38 @@ def moduli(
 
 
 def velocity(
-    k: _T,
-    mu: _T,
-    rhob: _T,
-) -> tuple[_T, _T, _T, _T]:
+    k: ArrayAnyDOrFloat,
+    mu: ArrayAnyDOrFloat,
+    rhob: ArrayAnyDOrFloat,
+) -> tuple[ArrayAnyDOrFloat, ArrayAnyDOrFloat, ArrayAnyDOrFloat, ArrayAnyDOrFloat]:
     """
     Calculate velocity, acoustic impedance and vp/vs ratio from elastic moduli and density.
 
     Parameters
     ----------
-    k : np.ndarray, float
+    k
         Bulk modulus [Pa].
-    mu : np.ndarray, float
+    mu
         Shear modulus [Pa].
-    rhob : np.ndarray, float
+    rhob
         Bulk density [kg/m^3].
 
     Returns
     -------
-    tuple
-        vp, vs, ai, vp_vs : np.ndarray.
-        vp: pressure wave velocity [m/s], vs: shear wave velocity [m/s], ai: acoustic impedance [m/s x kg/m^3],
-        vp_vs: velocity ratio [fraction].
+    vp
+        Pressure wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vp_vs
+        Velocity ratio [fraction].
     """
-    vs = cast(_T, (mu / rhob) ** 0.5)
-    vp = cast(_T, ((k + 4 / 3 * mu) / rhob) ** 0.5)
-    ai = cast(_T, vp * rhob)
+    vs = cast(ArrayAnyDOrFloat, (mu / rhob) ** 0.5)
+    vp = cast(ArrayAnyDOrFloat, ((k + 4 / 3 * mu) / rhob) ** 0.5)
+    ai = cast(ArrayAnyDOrFloat, vp * rhob)
     with np.errstate(divide="ignore", invalid="ignore"):
         # vs=0 is valid for Newtonian fluids (mu=0); vp/vs → inf is the correct result
-        vp_vs = cast(_T, vp / vs)
+        vp_vs = cast(ArrayAnyDOrFloat, vp / vs)
 
     return vp, vs, ai, vp_vs

--- a/src/rock_physics_open/equinor_utilities/std_functions/reflection_eq.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/reflection_eq.py
@@ -12,27 +12,26 @@ def _refl_models(
     k: npt.NDArray[np.float64] | float = 2.0,
     mod: Literal["aki_richards", "smith_gidlow"] = "aki_richards",
 ) -> npt.NDArray[np.float64]:
-    """Calculate reflect coeff.
+    """Compute two-term reflection coefficients between layer pairs.
 
     Parameters
     ----------
-    vp : np.ndarray
-        vp array.
-    vs : np.ndarray
-        vs array.
-    rho : np.ndarray
-        rho array.
-    theta : float, np.ndarray
-        Theta value.
-    k : float, np.ndarray, optional
-        By default 2.0.
-    mod : str, optional
-        By default 'aki_richards'.
+    vp
+        Compressional wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    rho
+        Bulk density [kg/m^3].
+    theta
+        Incidence angle [degree].
+    k
+        Background Vp/Vs ratio, by default 2.0.
+    mod
+        Reflection model, by default ``'aki_richards'``.
 
     Returns
     -------
-    np.ndarray
-        Reflect coeff.
+    Reflection coefficient per interface [ratio].
     """
     theta = theta / 180 * np.pi
     r_vp = (vp[1:] - vp[0:-1]) / (vp[0:-1] + vp[1:])
@@ -69,21 +68,20 @@ def aki_richards(
 
     Parameters
     ----------
-    vp : np.ndarray
+    vp
         Pressure wave velocity [m/s].
-    vs : np.ndarray
+    vs
         Shear wave velocity [m/s].
-    rho : np.ndarray
+    rho
         Density [kg/m^3].
-    theta : np.ndarray
+    theta
         Angle of incident ray [radians].
-    k : float, np.ndarray
+    k
         Background vp/vs [unitless].
 
     Returns
     -------
-    refl_coeff : np.ndarray
-        Reflection coefficient [unitless].
+    Reflection coefficient [unitless].
     """
     return _refl_models(vp, vs, rho, theta, k, mod="aki_richards")
 
@@ -100,21 +98,19 @@ def smith_gidlow(
 
     Parameters
     ----------
-    vp : np.ndarray
+    vp
         Pressure wave velocity [m/s].
-    vs : np.ndarray
+    vs
         Shear wave velocity [m/s].
-    rho : np.ndarray
+    rho
         Density [kg/m^3].
-    theta : np.ndarray
+    theta
         Angle of incident ray [radians].
-    k : float, np.ndarray
+    k
         Background vp/vs [unitless].
 
     Returns
     -------
-    refl_coeff : np.ndarray
-        Reflection coefficient [unitless].
+    Reflection coefficient [unitless].
     """
-
     return _refl_models(vp, vs, rho, theta, k, mod="smith_gidlow")

--- a/src/rock_physics_open/equinor_utilities/std_functions/rho.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/rho.py
@@ -14,17 +14,16 @@ def rho_b(
 
     Parameters
     ----------
-    phi: np.ndarray
+    phi
         Porosity [fraction].
-    rho_f: np.ndarray
+    rho_f
         Fluid bulk density [kg/m^3].
-    rho_mat: np.ndarray
+    rho_mat
         Matrix bulk density [kg/m^3].
 
     Returns
     -------
-    np.ndarray
-        rhob: bulk density [kg/m^3].
+    Bulk density [kg/m^3].
     """
     return phi * rho_f + (1 - phi) * rho_mat
 
@@ -36,24 +35,24 @@ def rho_m(
     rho_min: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Calculates matrix density as a combination of cement fraction and minerals
+    Calculates matrix density as a combination of cement fraction and minerals.
+
     fracCem is defined as cement fraction relative to total volume.
 
     Parameters
     ----------
-    frac_cem : np.ndarray
+    frac_cem
         Cement fraction [fraction].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    rho_cem : np.ndarray
+    rho_cem
          Cement density [kg/m^3].
-    rho_min : np.ndarray
+    rho_min
          Mineral density [kg/m^3].
 
     Returns
     -------
-    np.ndarray
-        rho_mat: matrix density [kg/m^3]
+    Matrix density [kg/m^3].
     """
     idx = np.logical_and(phi >= 0.0, phi < 1.0)
     if np.sum(idx) != len(phi):

--- a/src/rock_physics_open/equinor_utilities/std_functions/voigt_reuss_hill.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/voigt_reuss_hill.py
@@ -14,22 +14,23 @@ def voigt(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f1 : np.ndarray
+    f1
         Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray.
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa]
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     f2 = 1 - f1
     k_v = f1 * k1 + f2 * k2
@@ -50,22 +51,23 @@ def voigt_reuss_hill(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f1 : np.ndarray
+    f1
         Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa]
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     k_v, mu_v = voigt(k1, mu1, k2, mu2, f1)
     k_r, mu_r = reuss(k1, mu1, k2, mu2, f1)
@@ -88,13 +90,17 @@ def multi_voigt_reuss_hill(
 
     Parameters
     ----------
-    varargin : np.ndarray
+    *varargin
+        Flat sequence ``(k1, mu1, f1, ..., kn, mun, fn)`` giving the bulk
+        modulus [Pa], shear modulus [Pa] and volume fraction [fraction] of
+        each phase. Fractions must sum to 1.0.
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa].
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     k_min = np.array(varargin[::3])
     mu_min = np.array(varargin[1::3])
@@ -124,22 +130,23 @@ def reuss(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    f1 : np.ndarray
+    f1
         Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray.
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa].
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     f2 = 1 - f1
 

--- a/src/rock_physics_open/equinor_utilities/std_functions/walton.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/walton.py
@@ -14,26 +14,25 @@ def walton_smooth(
 
     Parameters
     ----------
-    k : np.ndarray
+    k
         Bulk modulus of grain mineral [Pa].
-    mu : np.ndarray
+    mu
         Shear modulus of grain mineral [Pa].
-    phi : np.ndarray
+    phi
         Critical porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective Pressure = (Lithostatic - Hydrostatic) pressure [Pa].
-    coord : float or np.ndarray
+    coord
         Coordination number, i.e. number of grain contract per grain. If not provided a porosity based estimate is
         used [unitless].
 
     Returns
     -------
-    tuple
-        k_dry , mu_dry : np.ndarray.
-        k_dry	Bulk modulus at effective pressure p,
-        mu_dry	Shear modulus at effective pressure p.
+    k_dry
+        Bulk modulus at effective pressure p.
+    mu_dry
+        Shear modulus at effective pressure p.
     """
-
     n = 25.98805 * phi**2 - 43.7622 * phi + 21.6719 if coord is None else coord
 
     pr_min = (3 * k - 2 * mu) / (2 * (3 * k + mu))

--- a/src/rock_physics_open/equinor_utilities/std_functions/wood_brie.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/wood_brie.py
@@ -1,10 +1,13 @@
 from collections.abc import Sequence
-from typing import TypeVar, overload
+from typing import overload
 
 import numpy as np
 import numpy.typing as npt
 
-from rock_physics_open.equinor_utilities.various_utilities.types import Array1D
+from rock_physics_open.equinor_utilities.various_utilities.types import (
+    Array1D,
+    Array1DOrFloat,
+)
 
 
 def brie(
@@ -21,27 +24,25 @@ def brie(
 
     Parameters
     ----------
-    s_gas : np.ndarray
+    s_gas
         Gas saturation [ratio].
-    k_gas : np.ndarray
+    k_gas
         Gas bulk modulus [Pa].
-    s_brine : np.ndarray
+    s_brine
         Brine saturation [ratio].
-    k_brine : np.ndarray
+    k_brine
         Brine bulk modulus [Pa].
-    s_oil : np.ndarray
+    s_oil
         Oil saturation [ratio].
-    k_oil : np.ndarray
+    k_oil
         Oil bulk modulus [Pa].
-    e : float or np.ndarray
+    e
         Exponent in Brie function [unitless].
 
     Returns
     -------
-    np.ndarray
-        k: effective bulk modulus [Pa].
+    Effective bulk modulus [Pa].
     """
-
     # Reuss average for fluids, catch zero fluid saturations
     idx = s_brine + s_oil > 0
     k_liquid = np.zeros(k_brine.shape)
@@ -62,22 +63,23 @@ def wood(
 
     Parameters
     ----------
-    s1 : np.ndarray
+    s1
         Saturation of phase 1 [ratio].
-    k1 : np.ndarray
+    k1
         Bulk modulus of phase 1 [Pa].
-    rho1 : np.ndarray
+    rho1
         Density of phase 1 [kg/m^3].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    rho2 : np.ndarray
+    rho2
         Density of phase 2 [kg/m^3].
 
     Returns
     -------
-    tuple
-        k, rho : np.ndarray.
-        k: effective fluid bulk modulus [Pa], rho: effective fluid density [kg/m^3].
+    k
+        Effective fluid bulk modulus [Pa].
+    rho
+        Effective fluid density [kg/m^3].
     """
     s2 = 1 - s1
 
@@ -85,9 +87,6 @@ def wood(
     rho = s1 * rho1 + s2 * rho2
 
     return k, rho
-
-
-_T = TypeVar("_T", float, Array1D[np.float64])
 
 
 @overload
@@ -105,8 +104,8 @@ def multi_wood(
 
 
 def multi_wood(
-    fractions: Sequence[_T],
-    bulk_moduli: Sequence[_T],
+    fractions: Sequence[Array1DOrFloat],
+    bulk_moduli: Sequence[Array1DOrFloat],
 ) -> float | Array1D[np.float64]:
     assert len(fractions) == len(bulk_moduli)
     sum_fractions = sum(fractions)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
@@ -15,9 +15,14 @@ def disp_result_stats(
 
     Parameters
     ----------
-    title : Title.
-    arr : items to display
-    names_arr : array of names.
+    title
+        Title.
+    arr
+        Items to display
+    names_arr
+        Array of names.
+    **kwargs
+        Keyword arguments for tkinter.
     """
     from tkinter import END, Entry, PhotoImage, Tk
 

--- a/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_dry_mod.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_dry_mod.py
@@ -26,28 +26,37 @@ def gassmann_dry_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    k_fl : np.ndarray
+    k_fl
         Fluid  bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [lg/m^3].
-    k_sat : np.ndarray
+    k_sat
         Saturated rock bulk modulus [Pa].
-    mu : np.ndarray
+    mu
         Saturated rock shear modulus [Pa].
-    rho_sat : np.ndarray
+    rho_sat
         Saturated rock density [kg/m^3].
-    por : np.ndarray
+    por
         Porosity [fraction].
 
     Returns
     -------
-    tuple
-        vp_dry, vs_dry, rho_dry, ai_dry, vpvs_dry, k_dry, mu : np.ndarray
-        vp_dry, vs_dry:  dry velocities [m/s], rho_dry: dry density [kg/m^3], ai_dry: dry acoustic impedance
-        [kg/m^3 x m/s], vpvs_dry: dry velocity ratio [unitless], k_dry, mu: dry bulk modulus and shear modulus (the
-        latter unchanged from saturated state) [Pa].
+    vp_dry
+        Dry compressional velocity [m/s].
+    vs_dry
+        Dry shear velocity [m/s].
+    rho_dry
+        Dry density [kg/m^3].
+    ai_dry
+        Dry acoustic impedance [kg/m^3 x m/s].
+    vpvs_dry
+        Dry velocity ratio [unitless].
+    k_dry
+        Dry bulk modulus [Pa].
+    mu
+        Shear modulus [Pa] (unchanged from saturated state).
     """
     rho_dry = rho_sat - por * rho_fl
     k_dry = std_functions.gassmann_dry(k_sat, por, k_fl, k_min)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_mod.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_mod.py
@@ -26,28 +26,37 @@ def gassmann_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    k_fl : np.ndarray
+    k_fl
         Fluid  bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [lg/m^3].
-    k_dry : np.ndarray
+    k_dry
         Dry rock bulk modulus [Pa].
-    mu : np.ndarray
+    mu
         Dry rock shear modulus [Pa].
-    rho_dry : np.ndarray
+    rho_dry
         Dry rock density [kg/m^3].
-    por : np.ndarray
+    por
         Porosity [fraction].
 
     Returns
     -------
-    tuple
-        vp_sat, vs_sat, rho_sat, ai_sat, vpvs_sat, k_sat, mu : np.ndarray
-        vp_sat, vs_sat:  saturated velocities [m/s], rho_sat: saturated density [kg/m^3], ai_sat: saturated acoustic
-        impedance [kg/m^3 x m/s], vpvs_sat: saturated velocity ratio [unitless], k_sat, mu: saturated bulk modulus and
-        shear modulus (the latter unchanged from dry state) [Pa].
+    vp_sat
+        Saturated compressional velocity [m/s].
+    vs_sat
+        Saturated shear velocity [m/s].
+    rho_sat
+        Saturated density [kg/m^3].
+    ai_sat
+        Saturated acoustic impedance [kg/m^3 x m/s].
+    vpvs_sat
+        Saturated velocity ratio [unitless].
+    k_sat
+        Saturated bulk modulus [Pa].
+    mu
+        Shear modulus [Pa] (unchanged from dry state).
     """
     rho_sat = rho_dry + por * rho_fl
     k_sat = std_functions.gassmann(k_dry, por, k_fl, k_min)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_sub_mod.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/gassmann_sub_mod.py
@@ -28,32 +28,41 @@ def gassmann_sub_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    k_fl_orig : np.ndarray
+    k_fl_orig
         Original fluid  bulk modulus [Pa].
-    rho_fl_orig : np.ndarray
+    rho_fl_orig
         Original fluid density [lg/m^3].
-    k_fl_sub : np.ndarray
+    k_fl_sub
         Substituted fluid  bulk modulus [Pa].
-    rho_fl_sub : np.ndarray
+    rho_fl_sub
         Substituted fluid density [lg/m^3].
-    k_sat_orig : np.ndarray
+    k_sat_orig
         Saturated rock bulk modulus with original fluid  [Pa].
-    mu : np.ndarray
+    mu
         Rock shear modulus [Pa].
-    rho_sat_orig : np.ndarray
+    rho_sat_orig
         Saturated rock density with original fluid [kg/m^3].
-    por : np.ndarray
+    por
         Porosity [fraction].
 
     Returns
     -------
-    tuple
-        vp_sat, vs_sat, rho_sat, ai_sat, vpvs_sat, k_sat, mu : np.ndarray
-        vp_sat, vs_sat:  saturated velocities [m/s], rho_sat: saturated density [kg/m^3], ai_sat: saturated acoustic
-        impedance [kg/m^3 x m/s], vpvs_sat: saturated velocity ratio [unitless], k_sat, mu: saturated bulk modulus and
-        shear modulus (the latter unchanged from dry state) [Pa].
+    vp_sat
+        Saturated compressional velocity [m/s].
+    vs_sat
+        Saturated shear velocity [m/s].
+    rho_sat
+        Saturated density [kg/m^3].
+    ai_sat
+        Saturated acoustic impedance [kg/m^3 x m/s].
+    vpvs_sat
+        Saturated velocity ratio [unitless].
+    k_sat
+        Saturated bulk modulus [Pa].
+    mu
+        Shear modulus [Pa] (unchanged from dry state).
     """
     rho_sat_sub = rho_sat_orig + por * (rho_fl_sub - rho_fl_orig)
     k_sat_sub = std_functions.gassmann2(k_sat_orig, k_fl_orig, k_fl_sub, por, k_min)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/hs_average.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/hs_average.py
@@ -26,30 +26,38 @@ def hs_average(
 
     Parameters
     ----------
-    k1 : np.ndarray
-        k1 array.
-    mu1 : np.ndarray
-        mu1 array.
-    rhob1 : np.ndarray
-        rhob1 array.
-    k2 : np.ndarray
-        k2 array.
-    mu2 : np.ndarray
-        mu2 array.
-    rhob2 : np.ndarray
-        rhob2 array.
-    f : float or np.ndarray
-        f value or array.
+    k1
+        Bulk modulus of phase 1 [Pa].
+    mu1
+        Shear modulus of phase 1 [Pa].
+    rhob1
+        Density of phase 1 [kg/m^3].
+    k2
+        Bulk modulus of phase 2 [Pa].
+    mu2
+        Shear modulus of phase 2 [Pa].
+    rhob2
+        Density of phase 2 [kg/m^3].
+    f
+        Fraction of phase 1 [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rhob, ai, vp_vs, k, mu : np.ndarray
-        vp: compressional wave velocity [m/s], vs: shear wave velocity [m/s], ai: acoustic impedance [m/s x kg/m^3],
-        vp_vs: velocity ratio [ratio], k: bulk modulus [Pa], mu: shear modulus [Pa]
-
+    vp
+        Compressional wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    rhob
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vp_vs
+        Velocity ratio [ratio].
+    k
+        Bulk modulus [Pa].
+    mu
+        Shear modulus [Pa].
     """
-
     k, mu = std_functions.hashin_shtrikman_average(k1, mu1, k2, mu2, f)
 
     rhob = rhob1 * f + rhob2 * (1 - f)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/pressure.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/pressure.py
@@ -11,32 +11,30 @@ def pressure(
     n: float,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Function to estimate overburden pressure and vertical effective stress (lithostatic pressure)
-    based on density.
+    Function to estimate overburden pressure and vertical effective stress (lithostatic pressure) based on density.
 
     Parameters
     ----------
-    rho : np.ndarray
-        Density log [kg/m3].
-    tvd_msl : np.ndarray
+    rho
+        Density log [kg/m^3].
+    tvd_msl
         Vertical depth log [m].
-    water_depth : float
+    water_depth
         Down to this point the difference between formation pressure and overburden pressure shall be zero [m].
-    p_form : float
+    p_form
         Formation pressure [Pa].
-    tvd_p_form : float
+    tvd_p_form
         Depth of formation pressure point [m].
-    n: float
+    n
         Biot coefficient [unitless].
 
     Returns
     -------
-    tuple
-        p_eff, p_lith : np.ndarray.
-        p_eff [Pa] - effective pressure,
-        p_lith [Pa] - overburden pressure.
+    p_eff
+        Effective pressure [Pa].
+    p_lith
+        Overburden pressure [Pa].
     """
-
     # Standard brine density with salinity 40000 ppm, 2 MPa and 4 deg. C
     rho_brine = 1.03e3
     # Gravity constant

--- a/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
@@ -15,8 +15,7 @@ def reflectivity(
     model: Literal["AkiRichards", "SmithGidlow"] = "AkiRichards",
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.bool_]]:
     """
-    Reflectivity model according to Aki and Richards or Smith and Gidlow for weak contrasts
-    and angles less than critical angle.
+    Reflectivity model according to Aki and Richards or Smith and Gidlow for weak contrasts and angles less than critical angle.
 
     In this function it is not allowed to have any missing values in the input logs.
     Instead of interpolating here without the user knowing, raise an input value
@@ -24,27 +23,26 @@ def reflectivity(
 
     Parameters
     ----------
-    vp_inp : np.ndarray
+    vp_inp
         Compressional wave velocity [m/s].
-    vs_inp : np.ndarray
+    vs_inp
         Shear wave velocity [m/s].
-    rho_inp : np.ndarray
+    rho_inp
         Bulk density [kg/m^3].
-    theta : float
+    theta
         Incidence angle [radians] (default value 0).
-    k : float
+    k
         Background Vp/Vs ratio [ratio] (default value 2.0).
-    model : str
+    model
         One of 'AkiRichards' (default) or 'SmithGidlow'.
 
     Returns
     -------
-    tuple
-        refl_coef, idx_inp : np.ndarray.
-        refl_coef: reflection coefficient [ratio],
-        idx_inp: index to accepted part of the input arrays [bool].
+    refl_coef
+        Reflection coefficient [ratio].
+    idx_inp
+        Index to accepted part of the input arrays [bool].
     """
-
     vp, vs, rho, theta_, k_ = cast(
         list[npt.NDArray[np.float64]],
         gen_utilities.dim_check_vector((vp_inp, vs_inp, rho_inp, theta, k)),

--- a/src/rock_physics_open/equinor_utilities/various_utilities/timeshift.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/timeshift.py
@@ -9,27 +9,27 @@ def time_shift_pp(
     multiplier: int,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Cumulative time shift calculation for 4D case. According to Equinor standard
-    the time shift is negative for an increase in velocity from base to monitor
-    survey.
+    Cumulative time shift calculation for 4D case.
+
+    According to Equinor standard the time shift is negative for an increase in velocity from base to monitor survey.
 
     Parameters
     ----------
-    tvd : np.ndarray
+    tvd
         True vertical depth along wellbore [m].
-    vp_base : np.ndarray
+    vp_base
         Initial Vp [m/s].
-    vp_mon : np.ndarray
+    vp_mon
         vp at time of monitor survey [m/s].
-    multiplier : int
+    multiplier
         Time shift multiplier.
 
     Returns
     -------
-    tuple
-        owt_pp_shift, twt_pp_shift : np.ndarray.
-        owt_pp_shift: one way time shift [ms],
-        twt_pp_shift: two way time shift [ms].
+    owt_pp_shift
+        One way time shift [ms].
+    twt_pp_shift
+        Two way time shift [ms].
 
     Notes
     -----
@@ -58,29 +58,29 @@ def time_shift_ps(
     multiplier: int,
 ) -> npt.NDArray[np.float64]:
     """
-    Cumulative time shift calculation for 4D case. According to Equinor standard
-    the time shift is negative for an increase in velocity from base to monitor
+    Cumulative time shift calculation for 4D case.
+
+    According to Equinor standard the time shift is negative for an increase in velocity from base to monitor
     survey.
 
     Parameters
     ----------
-    tvd : np.ndarray
+    tvd
         True vertical depth along wellbore [m].
-    vp_base : np.ndarray
+    vp_base
         Initial vp [m/s].
-    vp_mon : np.ndarray
+    vp_mon
         vs at time of monitor survey [m/s].
-    vs_base : np.ndarray
+    vs_base
         Initial vp [m/s].
-    vs_mon : np.ndarray
+    vs_mon
         vs at time of monitor survey [m/s].
-    multiplier : int
+    multiplier
         Time shift multiplier.
 
     Returns
     -------
-    np.ndarray
-        twt_ps_shift: two way time shift [ms]
+    twt_ps_shift: two way time shift [ms]
 
     Notes
     -----

--- a/src/rock_physics_open/equinor_utilities/various_utilities/types.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/types.py
@@ -9,6 +9,14 @@ Array1D = np.ndarray[tuple[int], np.dtype[_T]]
 Array2D = np.ndarray[tuple[int, int], np.dtype[_T]]
 Array3D = np.ndarray[tuple[int, int, int], np.dtype[_T]]
 Array4D = np.ndarray[tuple[int, int, int, int], np.dtype[_T]]
+ArrayAnyDOrFloat = TypeVar("ArrayAnyDOrFloat", npt.NDArray[np.float64], float)
+Array1DOrFloat = TypeVar("Array1DOrFloat", Array1D[np.float64], float)
+Array3Or4D = TypeVar(
+    "Array3Or4D",
+    Array3D[np.float64],
+    Array4D[np.float64],
+)
+ComplexOrFloat = TypeVar("ComplexOrFloat", np.complex128, np.float64)
 
 
 class OptCallable(Protocol):

--- a/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
@@ -23,35 +23,36 @@ def vp_vs_rho_stats(
     disp_results: bool = True,
 ) -> None:
     """
-    Utility to estimate statistics between vp-vs-rho sets - observed and estimated values. The results are displayed
-    on screen (optional) and saved to a .csv file. If the file exists, the results will be appended.
+    Utility to estimate statistics between vp-vs-rho sets - observed and estimated values.
+
+    The results are displayed on screen (optional) and saved to a .csv file. If the file exists, the results will be appended.
     The statistics consists of RAE (relative absolute error) [fraction], RRMSE (relative root mean squared error)
     [fraction] and R^2 (coefficient of determination) [fraction].
 
 
     Parameters
     ----------
-    vp_observed : np.ndarray or list
+    vp_observed
         Observed vp [m/s].
-    vs_observed : np.ndarray or list
+    vs_observed
         Observed vs [m/s].
-    rho_observed : np.ndarray or list
+    rho_observed
         Observed density [kg/m^3].
-    vp_estimated : np.ndarray or list
+    vp_estimated
         Estimated vp [m/s].
-    vs_estimated : np.ndarray or list
+    vs_estimated
         Estimated vs [m/s].
-    rho_estimated : np.ndarray or list
+    rho_estimated
         Estimated density [kg/m^3].
-    fname : str
+    fname
         File name for saved results.
-    estimated_set_names : str or list
+    estimated_set_names
         Name of the estimated vp-vs-rho set(s).
-    well_names : str or list
+    well_names
         Well name of the vp-vs-rho set(s).
-    file_mode : str
+    file_mode
         File open mode, default append.
-    disp_results : bool
+    disp_results
         Display results on screen.
     """
     if isinstance(estimated_set_names, str):
@@ -140,18 +141,18 @@ def _verify(
     file_mode: Literal["a", "w"],
 ):
     """Verify that arguments are either numpy arrays or lists of numpy arrays.
-    Raises
-    ------
-    ValueError
-        If not np.ndarray or list of such.
-    ValueError
-        If an entry contains NaNs.
-    ValueError
-        If an entry contains Infs.
-    ValueError
-        If mismatch in argument lengths.
-    ValueError
-        If file mode not 'a' or 'w'.
+
+    Parameters
+    ----------
+    *args
+        Arrays or lists of arrays to verify.
+    set_names
+        Names of the sets.
+    well_names
+        Names of the wells.
+    file_mode
+        File write mode.
+
     """
     # Verify that args are either numpy arrays or list of arrays
     for arg in args:

--- a/src/rock_physics_open/equinor_utilities/various_utilities/vrh_3_min.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/vrh_3_min.py
@@ -31,38 +31,47 @@ def min_3_voigt_reuss_hill(
 
     Parameters
     ----------
-    vp1 : np.ndarray
+    vp1
         Pressure wave velocity of phase 1 [m/s].
-    vs1 : np.ndarray
+    vs1
         Shear wave velocity of phase 1 [m/s].
-    rhob1 : np.ndarray
+    rhob1
         Bulk density of phase 1 [kg/m^3].
-    f1 : np.ndarray
+    f1
         Fraction of phase 1 [fraction].
-    vp2 : np.ndarray
+    vp2
         Pressure wave velocity of phase 2 [m/s].
-    vs2 : np.ndarray
+    vs2
         Shear wave velocity of phase 2 [m/s].
-    rhob2 : np.ndarray
+    rhob2
         Bulk density of phase 2 [kg/m^3].
-    f2 : np.ndarray
+    f2
         Fraction of phase 2 [fraction].
-    vp3 : np.ndarray
+    vp3
         Pressure wave velocity of phase 3 [m/s].
-    vs3 : np.ndarray
+    vs3
         Shear wave velocity of phase 3 [m/s].
-    rhob3 : np.ndarray
+    rhob3
         Bulk density of phase 3 [kg/m^3].
-    f3 : np.ndarray
+    f3
         Fraction of phase 3 [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rhob, ai, vp_vs, k, mu : np.ndarray.
-        vp: pressure wave velocity [m/s], vs: shear wave velocity [m/s], rhob: bulk density [kg/m^3],
-        ai: acoustic impedance [m/s x kg/m^3], vp_vs: velocity ratio [ratio],
-        k: effective bulk modulus [Pa], mu: effective shear modulus [Pa].
+    vp
+        Pressure wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    rhob
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vp_vs
+        Velocity ratio [ratio].
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
     """
     k1, mu1 = std_functions.moduli(vp1, vs1, rhob1)
     k2, mu2 = std_functions.moduli(vp2, vs2, rhob2)

--- a/src/rock_physics_open/fluid_models/brine_model/brine_properties.py
+++ b/src/rock_physics_open/fluid_models/brine_model/brine_properties.py
@@ -14,10 +14,25 @@ def brine_properties(
     salinity: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    :param salinity: Salinity of solution as [ppm] of NaCl.
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: Brine velocity vel_b [m/s], brine density den_b [kg/m^3], brine bulk modulus k_b [Pa]
+    Brine properties according to Batzle & Wang [1].
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+    salinity
+        Salinity of solution as [ppm] of NaCl.
+
+    Returns
+    -------
+    vel_b
+        Brine velocity [m/s].
+    den_b
+        Brine density [kg/m^3].
+    k_b
+        Brine bulk modulus [Pa].
     """
     vel_b = brine_primary_velocity(
         temperature=temperature,
@@ -39,11 +54,20 @@ def brine_density(
     salinity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    density of sodium chloride solutions, equation 27 in Batzle & Wang [1].
-    :param salinity: Salinity of solution in ppm
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: density of solution in [kg/m^3].
+    Density of sodium chloride solutions, equation 27 in Batzle & Wang [1].
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+    salinity
+        Salinity of solution in ppm
+
+    Returns
+    -------
+    density of solution in [kg/m^3].
     """
     pressure_mpa = pa_to_mpa(pressure)
     # Change unit of salinity to fraction
@@ -67,12 +91,20 @@ def brine_primary_velocity(
     salinity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Primary wave velocity of sodium chloride solutions, equation 29 in Batzle & Wang [1]
+    Primary wave velocity of sodium chloride solutions, equation 29 in Batzle & Wang [1].
 
-    :param salinity: Salinity of solution as [ppm] of sodium chloride
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: velocity of solution in m/s.
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+    salinity
+        Salinity of solution as [ppm] of sodium chloride
+
+    Returns
+    -------
+    velocity of solution in m/s.
     """
     # Change unit for salinity from ppm to fraction
     salinity_frac = salinity / 1.0e6
@@ -105,9 +137,17 @@ def water_density(
 ) -> npt.NDArray[Any]:
     """
     Density of water,, equation 27a in Batzle & Wang [1].
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: Density of water in [kg/m^3].
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+
+    Returns
+    -------
+    Density of water in [kg/m^3].
     """
     pressure_mpa = pa_to_mpa(pressure)
 
@@ -126,9 +166,17 @@ def water_primary_velocity(
 ) -> npt.NDArray[Any]:
     """
     Primary wave velocity of water, table 1 and equation 28 in Batzle & Wang [1].
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: primary wave velocity of water in m/s.
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+
+    Returns
+    -------
+    primary wave velocity of water in m/s.
     """
     pressure_mpa = pa_to_mpa(pressure)
 
@@ -154,9 +202,23 @@ def water(
     pressure: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    :param pressure: Formation pressure [Pa]
-    :param temperature: Temperature [°C]
-    :return: water_velocity [m/s], water_density [kg/m^3], water_bulk_modulus [Pa]
+    Water properties according to Batzle & Wang [1].
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C]
+    pressure
+        Formation pressure [Pa]
+
+    Returns
+    -------
+    water_velocity
+        Water velocity [m/s].
+    water_density
+        Water density [kg/m^3].
+    water_bulk_modulus
+        Water bulk modulus [Pa].
     """
     water_den = water_density(temperature, pressure)
     water_vel = water_primary_velocity(temperature, pressure)
@@ -172,6 +234,17 @@ def brine_viscosity(
     Brine viscosity according to Batzle & Wang [1].
 
     Based on equation 32.
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C].
+    salinity
+        Salinity [ppm].
+
+    Returns
+    -------
+    Result.
     """
     salinity_frac = salinity / 1.0e6
     return (

--- a/src/rock_physics_open/fluid_models/gas_model/gas_properties.py
+++ b/src/rock_physics_open/fluid_models/gas_model/gas_properties.py
@@ -23,12 +23,28 @@ def gas_properties(
     npt.NDArray[np.float64],
 ]:
     """
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param pressure: Formation pressure (Pa)
-    :param temperature: Temperature (Celsius).
-    :return: vel_gas [m/s], den_gas [kg/m^3], k_gas [Pa], eta_gas [cP]
-    """
+    Compute velocity, density, bulk modulus, and viscosity of a natural gas.
 
+    Parameters
+    ----------
+    temperature
+        Temperature [°C].
+    pressure
+        Formation pressure (Pa)
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    vel_gas
+        Gas velocity [m/s].
+    den_gas
+        Gas density [kg/m^3].
+    k_gas
+        Gas bulk modulus [Pa].
+    eta_gas
+        Gas viscosity [cP].
+    """
     den_gas = gas_density(
         absolute_temperature=celsius_to_kelvin(temperature),
         pressure=pressure,
@@ -54,9 +70,16 @@ def gas_properties(
 
 def molecular_weight(gas_gravity: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """
-    calculates molecular weight of a gas from gas gravity.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :return: The volume of the gas in kg/mol.
+    Calculates molecular weight of a gas from gas gravity.
+
+    Parameters
+    ----------
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    The volume of the gas in kg/mol.
     """
     return gas_gravity * AIR_WEIGHT
 
@@ -66,12 +89,19 @@ def molar_volume(
     pressure: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    calculates molar volume using the ideal gas law.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: The volume of the gas in m^3/mol.
-    """
+    Calculates molar volume using the ideal gas law.
 
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+
+    Returns
+    -------
+    The volume of the gas in m^3/mol.
+    """
     return gas_constant * absolute_temperature / pressure
 
 
@@ -81,11 +111,20 @@ def ideal_gas_density(
     gas_gravity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    calculates molar volume using the ideal gas law.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: The density of the gas in kg/m^3
+    Calculates molar volume using the ideal gas law.
+
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    The density of the gas in kg/m^3.
     """
     return molecular_weight(gas_gravity) / molar_volume(absolute_temperature, pressure)
 
@@ -95,9 +134,18 @@ def ideal_gas_primary_velocity(
     gas_gravity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :return: The compressional wave velocity of the gas in m/s.
+    Get ideal gas primary velocity.
+
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    The compressional wave velocity of the gas in m/s.
     """
     return np.sqrt(gas_constant * absolute_temperature / molecular_weight(gas_gravity))
 
@@ -108,10 +156,23 @@ def ideal_gas(
     gas_gravity: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: ideal_gas_velocity [m/s], ideal_gas_density [kg/m^3],
+    Get ideal gas properties.
+
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    ideal_gas_velocity
+        Ideal gas velocity [m/s].
+    ideal_gas_density
+        Ideal gas density [kg/m^3].
     """
     ideal_gas_den = ideal_gas_density(
         absolute_temperature=absolute_temperature,
@@ -130,7 +191,7 @@ def pseudoreduced_temperature(
     gas_gravity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    calculates pseudoreduced temperature, equation 9a from Batzle & Wang [1].
+    Calculates pseudoreduced temperature, equation 9a from Batzle & Wang [1].
 
     Uses relationship from
 
@@ -138,9 +199,16 @@ def pseudoreduced_temperature(
     Determination of acoustic velocities for natural gas: J. Petr.
     Tech., 22, 889-892.
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :return: Pseudoreduced temperature in kelvin.
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    Pseudoreduced temperature in kelvin.
     """
     return absolute_temperature / (94.72 + 170.75 * gas_gravity)
 
@@ -150,7 +218,7 @@ def pseudoreduced_pressure(
     gas_gravity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    calculates pseudoreduced pressure, equation 9a from Batzle & Wang [1].
+    Calculates pseudoreduced pressure, equation 9a from Batzle & Wang [1].
 
     Uses relationship from
 
@@ -158,9 +226,16 @@ def pseudoreduced_pressure(
     Determination of acoustic velocities for natural gas: J. Petr.
     Tech., 22, 889-892.
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param pressure: Confining pressure in Pa.
-    :return: Pseudoreduced pressure in Pa.
+    Parameters
+    ----------
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    Pseudoreduced pressure in Pa.
     """
     return pressure / (4.892 - 0.4048 * gas_gravity)
 
@@ -171,13 +246,20 @@ def compressibility_factor(
     gas_gravity: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    calculates compressibility hydro-carbon gas, equation 10b and 10c from
-    Batzle & Wang [1].
+    Calculates compressibility hydro-carbon gas, equation 10b and 10c from Batzle & Wang [1].
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: Gas compressibility - unitless
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    Gas compressibility - unitless
     """
     tpr = pseudoreduced_temperature(
         absolute_temperature=absolute_temperature,
@@ -206,12 +288,19 @@ def gas_density(
     """
     The density of hydro-carbon gas, using equation 10 from Batzle & Wang [1].
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: The density of the gas in kg/m^3
-    """
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
 
+    Returns
+    -------
+    The density of the gas in kg/m^3
+    """
     _, ideal_gas_den = ideal_gas(
         absolute_temperature=absolute_temperature,
         pressure=pressure,
@@ -232,10 +321,18 @@ def compressibility_rate_per_pseudoreduced_pressure(
     """
     Derivate of compressibility_factor with respect to pressure.
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in MPa.
-    :return: Derivative of the compressibility factor (unitless) with respect to pseudoreduced pressure
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in MPa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    Derivative of the compressibility factor (unitless) with respect to pseudoreduced pressure
     """
     tpr = pseudoreduced_temperature(absolute_temperature, gas_gravity)
 
@@ -263,10 +360,18 @@ def gas_bulk_modulus(
     """
     The bulk modulus of hydro-carbon gas, using equation 11 from Batzle & Wang [1].
 
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :return: The bulk modulus of the gas in Pa.
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air molar mass.
+
+    Returns
+    -------
+    The bulk modulus of the gas in Pa.
     """
     z = compressibility_factor(
         absolute_temperature=absolute_temperature,
@@ -301,10 +406,18 @@ def gas_viscosity(
     """
     The gas viscosity of hydrocarbon gas, using equations 12 and 13 of Batzle & Wang [1].
 
-    :param absolute_temperature: The absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :param gas_gravity: molar mass of gas relative to air mas.
-    :return: The gas viscosity of the gas in cP.
+    Parameters
+    ----------
+    absolute_temperature
+        The absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        molar mass of gas relative to air mas.
+
+    Returns
+    -------
+    The gas viscosity of the gas in cP.
     """
     temp_pr = pseudoreduced_temperature(absolute_temperature, gas_gravity)
 
@@ -337,18 +450,24 @@ def lee_gas_viscosity(
     gas_gravity: npt.NDArray[np.float64],
 ) -> np.ndarray:
     """
-    :param absolute_temperature: Absolute temperature of the gas in kelvin.
-    :param pressure: Confining pressure in Pa.
-    :param gas_gravity: specific gravity of gas relative to air.
-    :return: gas viscosity in cP
+    Get gas viscosity.
 
-    Reference
-    ---------
-    Lee, J. D., et al. (1966). "Viscosity of Natural Gas." In The American Institute of
-    Chemical Engineers Journal, Volume 12, Issue 6, pp. 1058-1062.
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature of the gas in kelvin.
+    pressure
+        Confining pressure in Pa.
+    gas_gravity
+        specific gravity of gas relative to air.
 
-    Original equation is given in imperial units. Inputs are transformed to temperature
-    in Fahrenheit and pressure in psi
+    Returns
+    -------
+    gas viscosity in cP
+
+    References
+    ----------
+    Lee, J. D., et al. (1966). "Viscosity of Natural Gas." In The American Institute of Chemical Engineers Journal, Volume 12, Issue 6, pp. 1058-1062. Original equation is given in imperial units. Inputs are transformed to temperature in Fahrenheit and pressure in psi
     """
     temp_far = celsius_to_fahrenheit(kelvin_to_celsius(absolute_temperature))
     pres_psi = pa_to_psi(pressure)

--- a/src/rock_physics_open/fluid_models/oil_model/dead_oil_density.py
+++ b/src/rock_physics_open/fluid_models/oil_model/dead_oil_density.py
@@ -17,11 +17,16 @@ def pressure_adjusted_dead_oil_density(
 
     Uses equation 18 from Batzle & Wang [1].
 
-    :param reference_density: The density [kg/m^3] of the dead oil at 15.6 degrees Celsius
-        and atmospheric pressure.
-    :param pressure: Formation pressure [Pa] to adjust to.
-    :return: Density of oil at given pressure and 21 degrees Celsius (~70 degrees
-    Fahrenheit). [kg/m^3]
+    Parameters
+    ----------
+    pressure
+        Formation pressure [Pa] to adjust to.
+    reference_density
+        The density [kg/m^3] of the dead oil at 15.6 degrees Celsius and atmospheric pressure.
+
+    Returns
+    -------
+    Density of oil at given pressure and 21 degrees Celsius (~70 degrees Fahrenheit). [kg/m^3]
     """
     pressure_mpa = pa_to_mpa(pressure)
     density_gcc = kg_m3_to_g_cc(reference_density)
@@ -42,9 +47,16 @@ def temperature_adjusted_dead_oil_density(
 
     Uses equation 19 from Batzle & Wang [1].
 
-    :param density_at_21c: The density [kg/m^3] of the dead oil at 21 degrees Celsius
-    :param temperature: Temperature [°C] of oil.
-    :return: Density of oil at given temperature. [kg/m^3]
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    density_at_21c
+        The density [kg/m^3] of the dead oil at 21 degrees Celsius
+
+    Returns
+    -------
+    Density of oil at given temperature. [kg/m^3]
     """
     density_at_21c_gcc = kg_m3_to_g_cc(density_at_21c)
     return g_cc_to_kg_m3(
@@ -62,11 +74,18 @@ def dead_oil_density(
 
     Uses equation 18 & 19 from Batzle & Wang [1].
 
-    :param reference_density: Density of oil at 15.6 degrees Celsius and atmospheric
-        pressure [kg/m^3]
-    :param pressure: Formation pressure [Pa] of oil
-    :param temperature: Temperature [°C] of oil.
-    :return: density of dead oil at given conditions (kg/m^3).
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil
+    reference_density
+        Density of oil at 15.6 degrees Celsius and atmospheric pressure [kg/m^3]
+
+    Returns
+    -------
+    density of dead oil at given conditions (kg/m^3).
     """
     density_p = pressure_adjusted_dead_oil_density(
         pressure=pressure,

--- a/src/rock_physics_open/fluid_models/oil_model/dead_oil_velocity.py
+++ b/src/rock_physics_open/fluid_models/oil_model/dead_oil_velocity.py
@@ -14,11 +14,18 @@ def dead_oil_velocity(
 
     Uses equation 20a from Batzle & Wang [1].
 
-    :param reference_density: Density of oil at 15.6 degrees Celsius and atmospheric
-        pressure [kg/m^3]
-    :param pressure: Formation pressure [Pa] of oil
-    :param temperature: Temperature [°C] of oil.
-    :return: primary velocity of dead oil in m/s.
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil
+    reference_density
+        Density of oil at 15.6 degrees Celsius and atmospheric pressure [kg/m^3]
+
+    Returns
+    -------
+    primary velocity of dead oil in m/s.
     """
     pressure_mpa = pa_to_mpa(pressure)
     density_gcc = kg_m3_to_g_cc(reference_density)

--- a/src/rock_physics_open/fluid_models/oil_model/han_batzle_oil_model.py
+++ b/src/rock_physics_open/fluid_models/oil_model/han_batzle_oil_model.py
@@ -24,16 +24,21 @@ def gas_apparent_density(
     gas_gravity: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    From Han and Batzle 2000: Equation 5
+    From Han and Batzle 2000: Equation 5.
+
+    Apparent liquid density of natural gas at standard conditions.
     The Rock Physics Handbook Ed. 3, Equation 6.22.42
-    Apparent liquid density of natural gas at standard conditions
 
-    Args:
-        oil_density (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
-        gas_gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
+    Parameters
+    ----------
+    oil_density
+        oil density at standard conditions [kg/m^3]
+    gas_gravity
+        gas gravity relative to air [unitless]
 
-    Returns:
-        ArrayLikeFloat: gas liquid density [kg/m^3]
+    Returns
+    -------
+    gas liquid density [kg/m^3]
     """
     scalar_input = inputs_are_scalar(oil_density, gas_gravity)
     oil_density_arr = as_float_array(oil_density)
@@ -54,21 +59,27 @@ def pseudo_liquid_density(
     gas_coefficient: float = 0.113,
 ) -> npt.NDArray[np.float64]:
     """
-    From Han and Batzle 2000: equation 7
+    From Han and Batzle 2000: equation 7.
+
     The Rock Physics Handbook Ed. 3, Equation 6.22.43-44
     Calculate the pseudo liquid density at standard conditions.
     With the default setting for the 'gas_coefficient', this is adapted to
-    the Han and Batzle model for live oil velocity
+    the Han and Batzle model for live oil velocity.
 
-    Args:
-        gor (ArrayLikeFloat): gas / oil volume ratio [unitless]
-        oil_density (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
-        gas_gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
-        gas_coefficient: (float): empirical gas coefficient
+    Parameters
+    ----------
+    oil_density
+        Oil density at standard conditions [kg/m^3].
+    gor
+        Gas / oil volume ratio [unitless].
+    gas_gravity
+        Gas gravity relative to air [unitless].
+    gas_coefficient
+        Empirical gas coefficient.
 
-
-    Returns:
-        ArrayLikeFloat: pseudo liquid density
+    Returns
+    -------
+    pseudo liquid density
     """
     # Calculate the apparent volume fraction of the pseudo-liquid gas
     # at standard conditions
@@ -99,19 +110,26 @@ def density_correction_vasquez_beggs_ahmed(
     rho0: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Correction to Batzle and Wang 1992 oil density model for pressures above
-    bubble point. This method is referred to as 'a more widely used correction'.
-    The Rock Physics Handbook, 3rd ed, 2020: Equation 6.22.38-40
+    Correction to Batzle and Wang 1992 oil density model for pressures above bubble point.
 
-    Args:
-        gor (ArrayLikeFloat): gas / oil ratio [l/l]. The empirical constants assume
-            this is in l/l (SI convention) not scf/STB as in the original paper.
-        temp (ArrayLikeFloat): temperature [°C]
-        gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
-        rho0 (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
+    This method is referred to as 'a more widely used correction'.
+    The Rock Physics Handbook, 3rd ed, 2020: Equation 6.22.38-40.
 
-    Returns:
-        ArrayLikeFloat: exponent for correction of pressures above bubble point
+    Parameters
+    ----------
+    gor
+        Gas / oil ratio [l/l]. The empirical constants assume
+        this is in l/l (SI convention) not scf/STB as in the original paper.
+    temp
+        Temperature [°C].
+    gravity
+        Gas gravity relative to air [unitless].
+    rho0
+        Oil density at standard conditions [kg/m^3].
+
+    Returns
+    -------
+    exponent for correction of pressures above bubble point
     """
     scalar_input = inputs_are_scalar(gor, temp, gravity, rho0)
     gor_arr = as_float_array(gor)
@@ -138,19 +156,26 @@ def han_batzle_live_oil_velocity(
     gas_gravity: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Han and Batzle 2000: oil velocity model, equation 10-16
-    The Rock Physics Handbook Ed. 3, Equation 6.22.52
+    Han and Batzle 2000: oil velocity model, equation 10-16.
 
-    Args:
-        temperature (ArrayLikeFloat): temperature [°C]
-        pressure (ArrayLikeFloat): formation pressure [Pa]
-        reference_density (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
-        gas_oil_ratio (ArrayLikeFloat): gas / Oil volume ratio [l/l]
-        gas_gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
+    The Rock Physics Handbook Ed. 3, Equation 6.22.52.
 
+    Parameters
+    ----------
+    temperature
+        Temperature [°C].
+    pressure
+        Formation pressure [Pa].
+    reference_density
+        Oil density at standard conditions [kg/m^3].
+    gas_oil_ratio
+        Gas / Oil volume ratio [l/l].
+    gas_gravity
+        Gas gravity relative to air [unitless].
 
-    Returns:
-        ArrayLikeFloat: oil velocity [m/s]
+    Returns
+    -------
+    Oil velocity [m/s].
     """
     # Estimate the bubble point pressure and identify pressure
     # values above and below bubble point
@@ -219,20 +244,25 @@ def han_batzle_live_oil_density(
     gas_gravity: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Correction to the Batzle and Wang 1992 live oil density model
-    for pressures above bubble point
+    Correction to the Batzle and Wang 1992 live oil density model for pressures above bubble point.
 
-    Args:
-        temperature (ArrayLikeFloat): temperature [°C]
-        pressure (ArrayLikeFloat): formation pressure [Pa]
-        reference_density (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
-        gas_oil_ratio (ArrayLikeFloat): gas / Oil volume ratio [l/l]
-        gas_gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
+    Parameters
+    ----------
+    temperature
+        Temperature [°C].
+    pressure
+        Formation pressure [Pa].
+    reference_density
+        Oil density at standard conditions [kg/m^3].
+    gas_oil_ratio
+        Gas / Oil volume ratio [l/l].
+    gas_gravity
+        Gas gravity relative to air [unitless].
 
-    Returns:
-        ArrayLikeFloat: oil density [kg/m^3]
+    Returns
+    -------
+    Oil density [kg/m^3].
     """
-
     # Estimate the bubble point pressure and identify pressure
     # values above and below bubble point
     scalar_input = inputs_are_scalar(

--- a/src/rock_physics_open/fluid_models/oil_model/live_oil_density.py
+++ b/src/rock_physics_open/fluid_models/oil_model/live_oil_density.py
@@ -20,12 +20,20 @@ def live_oil_density(
 
     Equation 24 in Batzle & Wang [1].
 
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param temperature: Temperature [°C] of oil.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :return: Density of live oil [kg/m^3].
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+
+    Returns
+    -------
+    Density of live oil [kg/m^3].
     """
     scalar_input = inputs_are_scalar(
         temperature,
@@ -58,17 +66,24 @@ def live_oil_pseudo_density(
     gas_gravity: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Pseudo density used to substitute reference density in dead_oil_wave_velocity
-    for live oils.
+    Pseudo density used to substitute reference density in dead_oil_wave_velocity for live oils.
 
     Equation 22 in Batzle & Wang [1].
 
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param temperature: Temperature [°C] of oil.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :return: Pseudo-density of live oil [kg/m^3].
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+
+    Returns
+    -------
+    Pseudo-density of live oil [kg/m^3].
     """
     scalar_input = inputs_are_scalar(
         temperature,
@@ -100,12 +115,21 @@ def live_oil_volume_factor(
 ) -> npt.NDArray[np.float64]:
     """
     Volume factor derived by Standing (1962), equation 23 in Batzle & Wang [1].
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param temperature: Temperature [°C] of oil.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :return: A volume factor in calculating pseudo-density of live oil [unitless].
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+
+    Returns
+    -------
+    A volume factor in calculating pseudo-density of live oil [unitless].
     """
     scalar_input = inputs_are_scalar(
         temperature,

--- a/src/rock_physics_open/fluid_models/oil_model/live_oil_velocity.py
+++ b/src/rock_physics_open/fluid_models/oil_model/live_oil_velocity.py
@@ -18,13 +18,22 @@ def live_oil_velocity(
 
     Substitute Equation 22 in Equation 20 of Batzle & Wang [1].
 
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param pressure: Formation pressure [Pa] of oil
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param temperature: Temperature [°C] of oil.
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :return: Primary wave velocity of live oil [m/s].
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+
+    Returns
+    -------
+    Primary wave velocity of live oil [m/s].
     """
     scalar_input = inputs_are_scalar(
         temperature, pressure, reference_density, gas_oil_ratio, gas_gravity

--- a/src/rock_physics_open/fluid_models/oil_model/oil_bubble_point.py
+++ b/src/rock_physics_open/fluid_models/oil_model/oil_bubble_point.py
@@ -15,21 +15,31 @@ def bp_standing(
     temperature: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Reservoir oils include some natural gas in solution. The pressure at which
-    this natural gas begins to come out of solution and form bubbles is known
+    Reservoir oils include some natural gas in solution.
+
+    The pressure at which this natural gas begins to come out of solution and form bubbles is known
     as the bubble point pressure. See https://petrowiki.org/Oil_bubblepoint_pressure
     Based on the correlation from:
     Standing, M. B. "A pressure-volume-temperature correlation for mixtures of
     California oils and gases." Drilling and Production Practice. American
     Petroleum Institute, 1947.
-    Uses refinement described here: https://petrowiki.org/Oil_bubblepoint_pressure
-    :param density: density of oil at room conditions [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param temperature: temperature of oil [°C]
-    :return: bubble point pressure [Pa]
-    """
+    Uses refinement described here: https://petrowiki.org/Oil_bubblepoint_pressure.
 
+    Parameters
+    ----------
+    density
+        density of oil at room conditions [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+    temperature
+        temperature of oil [°C]
+
+    Returns
+    -------
+    bubble point pressure [Pa].
+    """
     # Standing, M.B. (1947) uses:
     # * pressure in psi
     # * temperature in F
@@ -90,21 +100,27 @@ def max_gor_standing(
     temperature: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Calculate the maximum amount of gas that can be dissolved in
-    an oil for a given gas gravity, oil density, pressure and temperature.
+    Calculate the maximum amount of gas that can be dissolved in an oil for a given gas gravity, oil density, pressure and temperature.
+
     The result is given as gas/oil ratio.
     Standing 1962, The Rock Physics Handbook, 3rd ed. 2020,
-    Equation 6.22.28
+    Equation 6.22.28.
 
 
-    Args:
-        density (ArrayLikeFloat): oil density at standard conditions [kg/m^3]
-        pressure (ArrayLikeFloat): formation pressure [Pa]
-        gas_gravity (ArrayLikeFloat): gas gravity relative to air [unitless]
-        temperature (ArrayLikeFloat): temperature [°C]
+    Parameters
+    ----------
+    density
+        Oil density at standard conditions [kg/m^3].
+    pressure
+        Formation pressure [Pa].
+    gas_gravity
+        Gas gravity relative to air [unitless].
+    temperature
+        Temperature [°C].
 
-    Returns:
-        ArrayLikeFloat: gas/oil ratio [l/l]
+    Returns
+    -------
+    gas/oil ratio [l/l]
     """
     scalar_input = inputs_are_scalar(density, pressure, gas_gravity, temperature)
     density_arr = as_float_array(density)

--- a/src/rock_physics_open/fluid_models/oil_model/oil_properties.py
+++ b/src/rock_physics_open/fluid_models/oil_model/oil_properties.py
@@ -31,37 +31,54 @@ def oil_properties(
     model_version: ModelVersionType = "HB",
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Default parameter setting is now to use the more correct Han & Batzle 2000 model
-    for live oil properties above bubble point.
+    Default parameter setting is now to use the more correct Han & Batzle 2000 model for live oil properties above bubble point.
 
     Pressure values below bubble point will
     give NaN, as this is a non-physical state for the oil.
 
-    :param temperature: Temperature [°C] of oil.
-    :param pressure: Formation pressure [Pa] of oil
-    :param rho0: Density of the oil without dissolved gas at 15.6 degrees Celsius and
-                 atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param gas_gravity: Gas Gravity, molar mass of gas relative to air molar mas.
-    :param model_version: model_version: Model to use for live-oil properties. "BW" selects the
-        Batzle-Wang (1992) model, which returns approximate values across all
-        pressures and issues a warning when used below the bubble-point pressure.
-        "HB" selects the Han-Batzle (2000) model, which includes corrections for
-        pressures above the bubble point and returns NaN for pressures below the
-        bubble-point pressure.
-    :return: vel_oil [m/s], den_oil [kg/m^3], k_oil [Pa]
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil
+    rho0
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        Gas Gravity, molar mass of gas relative to air molar mas.
+    model_version
+        model_version: Model to use for live-oil properties. "BW" selects the Batzle-Wang (1992) model, which returns approximate values across all pressures and issues a warning when used below the bubble-point pressure. "HB" selects the Han-Batzle (2000) model, which includes corrections for pressures above the bubble point and returns NaN for pressures below the bubble-point pressure.
+
+    Returns
+    -------
+    vel_oil
+        Oil velocity [m/s].
+    den_oil
+        Oil density [kg/m^3].
+    k_oil
+        Oil bulk modulus [Pa].
     """
     # Since live_oil with gas_oil_ratio=0.0 is not equal to dead oil
     # we use an apodization function to interpolate between the two
 
-    def triangular_window(x: npt.NDArray[np.float64], length: int = 2):
+    def triangular_window(
+        x: npt.NDArray[np.float64], length: int = 2
+    ) -> npt.NDArray[np.float64]:
         """
-        A triangular window function around the origin, 1.0 at x=0.0, linear
-        and 0.0 outside the window.
-        :param length: total length of the window, ie., function is nonzero in
-            [-length/2, length/2].
-        :param x: numpy array containing x'es to evaluate the window at
-        :return: value of window function at x.
+        A triangular window function around the origin, 1.0 at x=0.0, linear and 0.0 outside the window.
+
+        Parameters
+        ----------
+        x
+            numpy array containing x'es to evaluate the window at
+        length
+            total length of the window, ie., function is nonzero in [-length/2, length/2].
+
+        Returns
+        -------
+        value of window function at x.
         """
         x = np.asarray(x)  # Ensure x is a numpy array
         window = np.clip((np.abs(x) - length / 2) / (length / 2), 0, 1)
@@ -108,13 +125,23 @@ def dead_oil(
     reference_density: ArrayLikeFloat,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param pressure: Formation pressure [Pa] of oil
-    :param temperature: Temperature [°C] of oil.
-    :return: dead_oil_velocity [m/s], dead_oil_density [kg/m^3],
+    Calculate the velocity and density of dead oil.
+
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil.
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+
+    Returns
+    -------
+    dead_oil_velocity
+        Dead oil velocity [m/s].
+    dead_oil_density
+        Dead oil density [kg/m^3].
     """
     scalar_input = inputs_are_scalar(temperature, pressure, reference_density)
     temperature_arr = as_float_array(temperature)
@@ -145,17 +172,29 @@ def live_oil(
     model_version: ModelVersionType = "HB",
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    We introduce the correction to live oil properties above bubble point
-    that is included in the Han and Batzle 2000 paper as a default.
+    We introduce the correction to live oil properties above bubble point that is included in the Han and Batzle 2000 paper as a default.
 
-    :param reference_density: Density of the oil without dissolved gas
-        at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
-    :param gas_oil_ratio: The volume ratio of gas to oil [l/l]
-    :param gas_gravity: molar mass of gas relative to air molar mas.
-    :param pressure: Formation pressure [Pa] of oil
-    :param temperature: Temperature [°C] of oil.
-    :param model_version: Batzle-Wang 1992 "BW" or Han-Batzle 2000 "HB"
-    :return: live_oil_velocity [m/s], live_oil_density [kg/m^3]
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil.
+    pressure
+        Formation pressure [Pa] of oil
+    reference_density
+        Density of the oil without dissolved gas at 15.6 degrees Celsius and atmospheric pressure. [kg/m^3]
+    gas_oil_ratio
+        The volume ratio of gas to oil [l/l]
+    gas_gravity
+        molar mass of gas relative to air molar mas.
+    model_version
+        Batzle-Wang 1992 "BW" or Han-Batzle 2000 "HB"
+
+    Returns
+    -------
+    live_oil_velocity
+        Live oil velocity [m/s].
+    live_oil_density
+        Live oil density [kg/m^3].
     """
     temperature_arr = as_float_array(temperature)
     pressure_arr = as_float_array(pressure)
@@ -212,16 +251,26 @@ def oil_viscosity(
     reference_density: ArrayLikeFloat,
 ) -> npt.NDArray[np.float64]:
     """
-    Calculate dead oil viscosity. If dissolved gas is present in the oil, the reference density
-    should be substituted by live oil density.
+    Calculate dead oil viscosity.
+
+    If dissolved gas is present in the oil, the reference density should be substituted by live oil density.
 
     Equations 25a, 25b, 26a & 26b in Batzle and Wang 1992
 
     Based on Beggs and Robinson 1975
 
-    :param temperature: Temperature [°C] of oil
-    :param pressure: Formation pressure [Pa] of oil
-    :param reference_density: Density of the oil without dissolved gas
+    Parameters
+    ----------
+    temperature
+        Temperature [°C] of oil
+    pressure
+        Formation pressure [Pa] of oil
+    reference_density
+        Density of the oil without dissolved gas
+
+    Returns
+    -------
+    Viscosity of oil.
     """
     scalar_input = inputs_are_scalar(temperature, pressure, reference_density)
     temperature_arr = as_float_array(temperature)

--- a/src/rock_physics_open/fluid_models/oil_model/oil_utilities.py
+++ b/src/rock_physics_open/fluid_models/oil_model/oil_utilities.py
@@ -7,11 +7,10 @@ ArrayLikeFloat: TypeAlias = npt.NDArray[np.float64] | float
 
 
 def as_float_array(value: ArrayLikeFloat) -> npt.NDArray[np.float64]:
-    """Ensure that an input will be cast to a numpy array with at least one
-    dimension"""
+    """Ensure that an input will be cast to a numpy array with at least one dimension."""
     return np.atleast_1d(np.asarray(value, dtype=np.float64))
 
 
 def inputs_are_scalar(*values: ArrayLikeFloat) -> bool:
-    """Test if all inputs are scalar values"""
+    """Test if all inputs are scalar values."""
     return all(np.asarray(value).ndim == 0 for value in values)

--- a/src/rock_physics_open/sandstone_models/cemented_shalysand_sandyshale_models.py
+++ b/src/rock_physics_open/sandstone_models/cemented_shalysand_sandyshale_models.py
@@ -62,64 +62,70 @@ def cemented_shaly_sand_sandy_shale_model(
 
     Parameters
     ----------
-    k_sst : np.ndarray
+    k_sst
         Sandstone matrix bulk modulus [Pa].
-    mu_sst : np.ndarray
+    mu_sst
         Sandstone matrix shear modulus [Pa].
-    rho_sst : np.ndarray
+    rho_sst
         Sandstone matrix bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Sandstone cement bulk density [kg/m^3].
-    k_mud : np.ndarray
+    k_mud
         Shale bulk modulus [Pa].
-    mu_mud : np.ndarray
+    mu_mud
         Shale shear modulus [Pa].
-    rho_mud : np.ndarray
+    rho_mud
         Shale bulk density [kg/m^3].
-    k_fl_sst : np.ndarray
+    k_fl_sst
         Fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_sst : np.ndarray
+    rho_fl_sst
         Fluid bulk density for sandstone fluid [kg/m^3].
-    k_fl_mud : np.ndarray
+    k_fl_mud
         Fluid bulk modulus for shale fluid [Pa].
-    rho_fl_mud : np.ndarray
+    rho_fl_mud
         Fluid bulk density for shale fluid[kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff_mud : np.ndarray
+    p_eff_mud
         Effective pressure in mud [Pa].
-    shale_frac : np.ndarray
+    shale_frac
         Shale fraction [fraction].
-    frac_cem : np.ndarray
+    frac_cem
         Cement volume fraction [fraction].
-    phi_c_sst : float
+    phi_c_sst
         Critical porosity for sandstone[fraction].
-    n_sst : float
+    n_sst
         Coordination number for sandstone [unitless].
-    shear_red_sst : float
+    shear_red_sst
         Shear reduction factor for sandstone [fraction].
-    phi_c_mud : float
+    phi_c_mud
         Critical porosity for mud [fraction].
-    phi_intr_mud : float
+    phi_intr_mud
         Intrinsic porosity for mud [fraction].
-    coord_num_func_mud : str
+    coord_num_func_mud
         Indication if coordination number should be calculated from porosity or kept constant for shale.
-    n_mud : float
+    n_mud
         Coordination number for shale [unitless].
-    shear_red_mud : float
+    shear_red_mud
         Shear reduction factor for mud [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rho, ai, vpvs  : (np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray)
-        vp [m/s] and vs [m/s], bulk density [kg/m^3], ai [m/s x kg/m^3], vpvs [ratio] of saturated rock.
+    vp
+        P-wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    rho
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vpvs
+        Vp/Vs ratio of saturated rock [ratio].
     """
-
     # Valid porosity values must not exceed (phi_c - frac_cem)
     # Assume that this only needs to be considered for the sandstone fraction
     (

--- a/src/rock_physics_open/sandstone_models/constant_cement_models.py
+++ b/src/rock_physics_open/sandstone_models/constant_cement_models.py
@@ -30,6 +30,8 @@ def constant_cement_model(
     npt.NDArray[np.float64],
 ]:
     """
+    Constant cement model.
+
     Constant cement model is a sandstone model that combined a cemented and a friable sand, so that a constant
     proportion of the rock volume is made up of grain-bonding cement. Variation in porosity is due to grain sorting,
     i.e. a well-sorted sand will have high porosity, and a poorly sorted one will have low porosity. In the extreme
@@ -52,41 +54,48 @@ def constant_cement_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement bulk density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    frac_cem : np.ndarray or float
+    frac_cem
         Cement fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor [fraction].
-    extrapolate_to_max_phi : bool
+    extrapolate_to_max_phi
         If True, the model will extrapolate to the maximum porosity value (phi_c - frac_cem) if the input porosity
         exceeds this value. If False, the model will return NaN for porosity values exceeding this limit.
 
     Returns
     -------
-    tuple
-        vp, vs, rho, ai, vpvs  : np.ndarray
-        vp [m/s] and vs [m/s], bulk density [kg/m^3], ai [m/s x kg/m^3], vpvs [ratio] of saturated rock.
+    vp
+        Compressional wave velocity of saturated rock [m/s].
+    vs
+        Shear wave velocity of saturated rock [m/s].
+    rho
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vpvs
+        Vp/Vs ratio [ratio].
     """
     k_zero, k_dry, mu = constant_cement_model_dry(
         k_min=k_min,
@@ -172,41 +181,43 @@ def constant_cement_model_dry(
     | tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]
 ):
     """
-    Dry rock version of the constant cement model. The method is identical to the constant cement model function,
-    except that a saturation step is not performed at the end.
+    Dry rock version of the constant cement model.
+
+    The method is identical to the constant cement model function, except that a saturation step is not performed at the end.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    k_cem : np.ndarray
+    k_cem
         Cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Cement shear modulus [Pa].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    frac_cem : float or np.ndarray
+    frac_cem
         Cement fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor [fraction].
-    extrapolate_to_max_phi : bool
+    extrapolate_to_max_phi
         If True, the model will extrapolate to the maximum porosity value (phi_c - frac_cem) if the input porosity
         exceeds this value. If False, the model will return NaN for porosity values exceeding this limit.
-    return_k_zero : bool
+    return_k_zero
         If True, the model will return the zero-porosity end member bulk modulus k_zero in addition to the dry rock
         bulk modulus k_dry and shear modulus mu.
 
     Returns
     -------
-    tuple
-        k_dry, mu : np.ndarray
-        Bulk modulus k [Pa] and shear modulus mu [Pa] of dry rock.
+    k_dry
+        Bulk modulus of dry rock [Pa].
+    mu
+        Shear modulus of dry rock [Pa].
     """
     # First check if there are input values that are unphysical, i.e. negative values, separate between dry and
     # saturated rock properties. Use the filter_input_log function to identify these values

--- a/src/rock_physics_open/sandstone_models/constant_cement_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/constant_cement_optimisation.py
@@ -44,44 +44,48 @@ def constant_cement_model_optimisation(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Cement bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Cement shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Cement density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [kg/m^3].
-    por : np.ndarray
+    por
         Inclusion porosity [ratio].
-    vp : np.ndarray
+    vp
         Compressional velocity log [m/s].
-    vs : np.ndarray
+    vs
         Shear velocity log [m/s].
-    rhob : np.ndarray
+    rhob
         Bulk density log [kg/m^3].
-    file_out_str : str
+    file_out_str
         Output file name (string) to store optimal parameters (pickle format).
-    display_results : bool
+    display_results
         Display optimal parameters in a window after run.
-    well_name : str
+    well_name
         Name of well to be displayed in info box title.
 
     Returns
     -------
-    tuple
-        vp_mod, vs_mod - modelled logs, vp_res, vs_res : np.ndarray
-        residual logs.
+    vp_mod
+        Modelled p-wave velocity log.
+    vs_mod
+        Modelled s-wave velocity log.
+    vp_res
+        P-wave velocity residual log.
+    vs_res
+        S-wave velocity residual log.
     """
-
     # Skip hardcoded Vp/Vs ratio
     def_vpvs = np.mean(vp / vs)
     # Set weight to vs to give vp and vs similar influence on optimisation

--- a/src/rock_physics_open/sandstone_models/contact_cement_model.py
+++ b/src/rock_physics_open/sandstone_models/contact_cement_model.py
@@ -28,8 +28,9 @@ def contact_cement_model(
     npt.NDArray[np.float64],
 ]:
     """
-    Contact cement model is a sandstone model where all variation in porosity is explained by variation in grain contact
-    cement. This is leads to the stiffest transition from critical porosity to the mineral point.
+    Contact cement model is a sandstone model where all variation in porosity is explained by variation in grain contact cement.
+
+    This is leads to the stiffest transition from critical porosity to the mineral point.
 
     Mineral properties k_min, muMin, rho_min are effective properties. For mixtures of minerals, effective properties
     are calculated by Hashin-Shtrikman or similar.
@@ -49,40 +50,46 @@ def contact_cement_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement bulk density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    frac_cem : float
+    frac_cem
         Cement fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rho, ai, vpvs  : np.ndarray
-        vp [m/s] and vs [m/s], bulk density [kg/m^3], ai [m/s x kg/m^3], vpvs [ratio] of saturated rock.
+    vp
+        Compressional wave velocity of saturated rock [m/s].
+    vs
+        Shear wave velocity of saturated rock [m/s].
+    rho
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vpvs
+        Vp/Vs ratio [ratio].
     """
-
     # Identify porosity values that are above (phi_c - frac_cem), for which the model is not defined
     (
         idx_phi,

--- a/src/rock_physics_open/sandstone_models/curvefit_sandstone_models.py
+++ b/src/rock_physics_open/sandstone_models/curvefit_sandstone_models.py
@@ -13,11 +13,28 @@ def curvefit_patchy_cement(
     shear_red: float,
     frac_cem: float,
 ) -> npt.NDArray[np.float64]:
-    """Run patchy_cement_model_weight with parameter optimisation for closest possible fit to observations
+    """Run patchy_cement_model_weight with parameter optimisation for closest possible fit to observations.
 
     Inputs: vp, vs, rho, por, k_fl, rho_fl, p_eff, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, phi_c
     Parameters to optimise for: frac_cem, shear_red, weight_k, weight_mu
     Optimise for vp, vs
+
+    Parameters
+    ----------
+    x_data
+        Input data array.
+    weight_k
+        Weight for bulk modulus.
+    weight_mu
+        Weight for shear modulus.
+    shear_red
+        Shear reduction factor.
+    frac_cem
+        Cement fraction.
+
+    Returns
+    -------
+    Result.
     """
     # Unpack x inputs
     # In calling function:
@@ -69,11 +86,24 @@ def curvefit_friable(
     phi_c: float,
     shear_red: float,
 ) -> npt.NDArray[np.float64]:
-    """Run friable sand model with parameter optimisation for closest possible fit to observations
+    """Run friable sand model with parameter optimisation for closest possible fit to observations.
 
     Inputs: vp, vs, por, k_fl, rho_fl, p_eff, k_min, mu_min, rho_min
     Parameters to optimise for: phi_c, shear_red
     Optimise for vp, vs
+
+    Parameters
+    ----------
+    x_data
+        Input data array.
+    phi_c
+        Critical porosity.
+    shear_red
+        Shear reduction factor.
+
+    Returns
+    -------
+    Result.
     """
     # Unpack x inputs
     k_min = x_data[:, 0]
@@ -115,11 +145,26 @@ def curvefit_constant_cement(
     shear_red: float,
     frac_cem: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
-    """Run constant_cement_model with parameter optimisation for closest possible fit to observations
+    """Run constant_cement_model with parameter optimisation for closest possible fit to observations.
 
     Inputs: vp, vs, por, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, k_fl, rho_fl
     Parameters to optimise for: phi_c, shear_red, frac_cem
     Optimise for vp, vs
+
+    Parameters
+    ----------
+    x_data
+        Input data array.
+    phi_c
+        Critical porosity.
+    shear_red
+        Shear reduction factor.
+    frac_cem
+        Cement fraction.
+
+    Returns
+    -------
+    Result.
     """
     # Unpack x inputs
     k_min = x_data[:, 0]

--- a/src/rock_physics_open/sandstone_models/friable_models.py
+++ b/src/rock_physics_open/sandstone_models/friable_models.py
@@ -28,8 +28,10 @@ def friable_model(
     npt.NDArray[np.float64],
 ]:
     """
-    Friable (non-cemented) sandstone model. All porosity variation is due to sorting, i.e. porosity filled with
-    smaller grains. This model is pressure sensitive, but without asymptotic behaviour, which could be expected.
+    Friable (non-cemented) sandstone model.
+
+    All porosity variation is due to sorting, i.e. porosity filled with smaller grains.
+    This model is pressure sensitive, but without asymptotic behaviour, which could be expected.
 
     The same model is also used for shale, with different set of parameters.
 
@@ -56,34 +58,41 @@ def friable_model(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure [Pa].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    coord_num_func : str
+    coord_num_func
         Indication if coordination number should be calculated from porosity or kept constant.
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rho, ai, vpvs  : np.ndarray
-        vp [m/s] and vs [m/s], bulk density [kg/m^3], ai [m/s x kg/m^3], vpvs [ratio] of saturated rock.
+    vp
+        Compressional wave velocity of saturated rock [m/s].
+    vs
+        Shear wave velocity of saturated rock [m/s].
+    rho
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vpvs
+        Vp/Vs ratio [ratio].
     """
     k_dry, mu = friable_model_dry(
         k_min=k_min,
@@ -154,28 +163,29 @@ def friable_model_dry(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure [Pa].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    coord_num_func : str
+    coord_num_func
         Indication if coordination number should be calculated from porosity or kept constant.
-    n : float | None
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor [fraction].
 
     Returns
     -------
-    tuple
-        k, mu : np.ndarray.
-        Bulk modulus k [Pa], shear modulus mu [Pa] of dry rock.
+    k
+        Bulk modulus of dry rock [Pa].
+    mu
+        Shear modulus of dry rock [Pa].
     """
     # Expand floats to arrays, check for equal length
     phi, phi_c_, shear_red_, k_min, mu_min, p_eff, n_ = cast(

--- a/src/rock_physics_open/sandstone_models/friable_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/friable_optimisation.py
@@ -43,40 +43,52 @@ def friable_model_optimisation(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Cement bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Cement shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Cement density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [kg/m^3].
-    por : np.ndarray
+    por
         Inclusion porosity [ratio].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure log [Pa].
-    vp : np.ndarray
+    vp
         Compressional velocity log [m/s].
-    vs : np.ndarray
+    vs
         Shear velocity log [m/s].
-    rhob : np.ndarray
+    rhob
         Bulk density log [kg/m^3].
-    file_out_str : str
+    file_out_str
         Output file name (string) to store optimal parameters (pickle format).
-    display_results : bool
+    display_results
         Display optimal parameters in a window after run.
-    well_name : str
+    well_name
         Name of well to be displayed in info box title.
 
     Returns
     -------
-    tuple
-        vp_mod, vs_mod, rhob_mod, ai_mod, vpvs_mod, vp_res, vs_res, rhob_res : np.ndarray
-        modelled logs, vp_res, vs_res, rho_res - residual logs.
+    vp_mod
+        Modelled p-wave velocity log.
+    vs_mod
+        Modelled s-wave velocity log.
+    rhob_mod
+        Modelled bulk density log.
+    ai_mod
+        Modelled acoustic impedance log.
+    vpvs_mod
+        Modelled Vp/Vs ratio log.
+    vp_res
+        P-wave velocity residual log.
+    vs_res
+        S-wave velocity residual log.
+    rhob_res
+        Bulk density residual log.
     """
-
     # Skip hardcoded Vp/Vs ratio
     def_vpvs = np.mean(vp / vs)
     # Set weight to vs to give vp and vs similar influence on optimisation

--- a/src/rock_physics_open/sandstone_models/friable_shalysand_sandyshale_models.py
+++ b/src/rock_physics_open/sandstone_models/friable_shalysand_sandyshale_models.py
@@ -57,60 +57,66 @@ def friable_shaly_sand_sandy_shale_model(
 
     Parameters
     ----------
-    k_sst : np.ndarray
+    k_sst
         Sandstone bulk modulus [Pa].
-    mu_sst : np.ndarray
+    mu_sst
         Sandstone shear modulus [Pa].
-    rho_sst : np.ndarray
+    rho_sst
         Sandstone bulk density [kg/m^3].
-    k_mud : np.ndarray
+    k_mud
         Shale bulk modulus [Pa].
-    mu_mud : np.ndarray
+    mu_mud
         Shale shear modulus [Pa].
-    rho_mud : np.ndarray
+    rho_mud
         Shale bulk density [kg/m^3].
-    k_fl_sst : np.ndarray
+    k_fl_sst
         Fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_sst : np.ndarray
+    rho_fl_sst
         Fluid bulk density for sandstone fluid [kg/m^3].
-    k_fl_mud : np.ndarray
+    k_fl_mud
         Fluid bulk modulus for shale fluid [Pa].
-    rho_fl_mud : np.ndarray
+    rho_fl_mud
         Fluid bulk density for shale fluid[kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff_sst : np.ndarray
+    p_eff_sst
         Effective pressure in sandstone [Pa].
-    p_eff_mud : np.ndarray
+    p_eff_mud
         Effective pressure in mud [Pa].
-    shale_frac : np.ndarray
+    shale_frac
         Shale fraction [fraction].
-    phi_c_sst : float
+    phi_c_sst
         Critical porosity for sandstone [fraction].
-    phi_c_mud : float
+    phi_c_mud
         Critical porosity for mud [fraction].
-    phi_intr_mud : float
+    phi_intr_mud
         Intrinsic shale porosity [fraction].
-    coord_num_func_sst : str
+    coord_num_func_sst
         Indication if coordination number should be calculated from porosity or kept constant for sandstone.
-    coord_num_func_mud : str
-        Indication if coordination number should be calculated from porosity or kept constant for shale.
-    n_sst : float
+    n_sst
         Coordination number for sandstone [unitless].
-    n_mud : float
+    coord_num_func_mud
+        Indication if coordination number should be calculated from porosity or kept constant for shale.
+    n_mud
         Coordination number for shale [unitless].
-    shear_red_sst : float
+    shear_red_sst
         Shear reduction factor for sandstone [fraction].
-    shear_red_mud : float
+    shear_red_mud
         Shear reduction factor for mud [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rho, ai, vpvs  : np.ndarray
-        vp [m/s] and vs [m/s], bulk density [kg/m^3], ai [m/s x kg/m^3], vpvs [ratio] of saturated rock.
+    vp
+        Compressional wave velocity of saturated rock [m/s].
+    vs
+        Shear wave velocity of saturated rock [m/s].
+    rho
+        Bulk density [kg/m^3].
+    ai
+        Acoustic impedance [m/s x kg/m^3].
+    vpvs
+        Vp/Vs ratio [ratio].
     """
-
     # Filter out values of phi that are above phi_c, assumed only to apply for the sandstone
     (
         idx_phi,

--- a/src/rock_physics_open/sandstone_models/patchy_cement_fluid_substitution_model.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_fluid_substitution_model.py
@@ -57,8 +57,9 @@ def patchy_cement_pressure_fluid_substitution(
     npt.NDArray[np.float64],
 ]:
     """
-    Patchy cement model, developed by Per Avseth and Norunn Skjei. A sandstone model in which part of the
-    matrix is pressure sensitive, and part is cemented.
+    Patchy cement model, developed by Per Avseth and Norunn Skjei.
+
+    A sandstone model in which part of the matrix is pressure sensitive, and part is cemented.
 
     Control parameters with default value:
     model_type = 'weight': A sample by sample weight between cemented (upper) and friable (lower) bound are calculated.
@@ -87,81 +88,88 @@ def patchy_cement_pressure_fluid_substitution(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral density [kg/m^3]
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement density [kg/m^3]
-    k_fl_old : np.ndarray
+    k_fl_old
         Initial fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_old : np.ndarray
+    rho_fl_old
         Initial fluid bulk density for sandstone fluid [kg/m^3].
-    k_fl_new : np.ndarray
+    k_fl_new
         Substituted fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_new : np.ndarray
+    rho_fl_new
         Substituted fluid bulk density for sandstone fluid [kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff_old : np.ndarray
+    p_eff_old
         Initial effective pressure [Pa].
-    p_eff_new : np.ndarray
+    p_eff_new
         Substituted effective pressure [Pa].
-    p_eff_low : float
-        Lower bound effective pressure [Pa].
-    frac_cem_up : float
-        Upper bound cement volume fraction [fraction].
-    frac_cem : cement fraction of constant cement model - representative for observed data. Must be lower than
-        frac_cem_up
-    shear_red : float
-        Shear reduction factor for sandstone [fraction].
-    phi_c : float
-        Critical porosity [fraction].
-    n : float
-        Coordination number [unitless].
-    coord_num_func : str
-        Indication if coordination number should be calculated from porosity or kept constant.
-    vp_old : np.ndarray
+    vp_old
         Initial p-wave velocity [m/s].
-    vs_old : np.ndarray
+    vs_old
         Initial s-wave velocity [m/s].
-    rho_b_old : np.ndarray
+    rho_b_old
         Initial bulk density [kg/m^3].
-    model_type : str
+    p_eff_low
+        Lower bound effective pressure [Pa].
+    frac_cem_up
+        Upper bound cement volume fraction [fraction].
+    frac_cem
+        frac_cem_up
+    shear_red
+        Shear reduction factor for sandstone [fraction].
+    phi_c
+        Critical porosity [fraction].
+    coord_num_func
+        Indication if coordination number should be calculated from porosity or kept constant.
+    n
+        Coordination number [unitless].
+    model_type
         Version of model, either 'weight' or 'cement_fraction'
-    phi_below_zero : str
+    phi_below_zero
         Control for handling of negative porosity samples.
-    phi_above_phi_c : str
+    phi_above_phi_c
         Control for handling of porosity samples above critical porosity.
-    k_sat_above_k_min : str
+    k_sat_above_k_min
         Control for handling of bulk modulus samples above mineral bulk modulus.
-    above_upper_bound : str
+    above_upper_bound
         Control for handling of samples above the upper bound.
-    below_lower_bound : str
+    below_lower_bound
         Control for handling of samples below the lower bound.
 
     Returns
     -------
-    tuple
-        vp_new, vs_new, rho_b_new, ai_new, vpvs_new, k_sat_new, mu_new, wk, wmu, idx_valid :
-        (np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray).
-        vp_new :Saturated P-velocity [m/s] after fluid and pressure substitution,
-        vs_new : Saturated S-velocity [m/s] after fluid and pressure substitution,
-        rho_b_new : Saturated density [kg/m3] after fluid and pressure substitution,
-        ai_new : Saturated acoustic impedance [kg/m3 x m/s] after fluid and pressure substitution,
-        vpvs_new : Saturated Vp/Vs ratio [unitless] after fluid and pressure substitution,
-        k_sat_new : New saturated rock bulk modulus [Pa],
-        mu_new : New shear modulus [Pa],
-        wk, wmu : weights for k and mu between upper and lower bound,
-        idx_valid : samples fluid substitution is performed
+    vp_new
+        Saturated P-velocity after fluid and pressure substitution [m/s].
+    vs_new
+        Saturated S-velocity after fluid and pressure substitution [m/s].
+    rho_b_new
+        Saturated density after fluid and pressure substitution [kg/m^3].
+    ai_new
+        Saturated acoustic impedance after fluid and pressure substitution [kg/m^3 x m/s].
+    vpvs_new
+        Saturated Vp/Vs ratio after fluid and pressure substitution [unitless].
+    k_sat_new
+        New saturated rock bulk modulus [Pa].
+    mu_new
+        New shear modulus [Pa].
+    wk
+        Weight for k between upper and lower bound.
+    wmu
+        Weight for mu between upper and lower bound.
+    idx_valid
+        Boolean mask of samples where fluid substitution is performed.
     """
-
     # Original saturated bulk and shear modulus
     k_sat_old, mu_old = std_functions.moduli(vp=vp_old, vs=vs_old, rhob=rho_b_old)
 
@@ -526,19 +534,22 @@ def _calculate_weight(
     force_full_range: bool = False,
 ) -> npt.NDArray[np.float64]:
     """
-    Calculates a weight for a value between a lower and upper bound. Used for moduli
-
+    Calculates a weight for a value between a lower and upper bound. Used for moduli.
 
     Parameters
     ----------
-    dry_modulus: value to be evaluated
-    low_modulus: lower bound
-    high_modulus: upper bound
-    force_full_range: do not clip weight to a range of [0.0, 1.0]
+    dry_modulus
+        Value to be evaluated.
+    low_modulus
+        Lower bound.
+    high_modulus
+        Upper bound.
+    force_full_range
+        Do not clip weight to a range of [0.0, 1.0].
 
     Returns
     -------
-    weight: value between [0.0, 1.0]
+    Weight between [0.0, 1.0]
     """
     idx = np.abs(high_modulus - low_modulus) < 2.0 * np.finfo(float).eps
     if np.any(idx):

--- a/src/rock_physics_open/sandstone_models/patchy_cement_model.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_model.py
@@ -30,10 +30,6 @@ def constant_cement_model_pcm(
     n: float,
     red_shear: float,
 ):
-    """
-    kdry, mydry = contantcementmodel_pcm(kmin, mymin, kcem, mycem, kzero, myzero, phi, cem_frac, phic, n, red_shear)
-    """
-
     #   Contact cement model (Dvorkin-Nur)for given cem_frac
     kcc, mycc = std_functions.dvorkin_contact_cement(
         frac_cem=cem_frac,
@@ -89,58 +85,61 @@ def patchy_cement_model_weight(
     npt.NDArray[np.float64],
 ]:
     """
-    Patchy cement model for sands that are a combination of friable model and constant cement model. No fluid or
-    pressure substitution. Input variables for weight of K and Mu determine the model's position between upper and
-    lower bound.
+    Patchy cement model for sands that are a combination of friable model and constant cement model.
+
+    No fluid or pressure substitution.
+    Input variables for weight of K and Mu determine the model's position between upper and lower bound.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement bulk density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure [Pa].
-    frac_cem : float
+    frac_cem
         Upper bound cement volume fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    coord_num_func : str
+    coord_num_func
         Indication if coordination number should be calculated from porosity or kept constant.
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor for sandstone [fraction].
-    weight_k : float
+    weight_k
         Weight between friable and cemented model for bulk modulus.
-    weight_mu : float
+    weight_mu
         Weight between friable and cemented model for shear modulus.
 
     Returns
     -------
-    tuple
-        k, mu, rhob, vp, vs : np.ndarray.
-        vp :Saturated P-velocity [m/s] after fluid and pressure substitution,
-        vs : Saturated S-velocity [m/s] after fluid and pressure substitution,
-        rhob : Saturated density [kg/m3] after fluid and pressure substitution,
-        k : Saturated rock bulk modulus [Pa],
-        mu : Shear modulus [Pa].
+    k
+        Saturated rock bulk modulus [Pa].
+    mu
+        Shear modulus [Pa].
+    rhob
+        Saturated density after fluid and pressure substitution [kg/m^3].
+    vp
+        Saturated P-velocity after fluid and pressure substitution [m/s].
+    vs
+        Saturated S-velocity after fluid and pressure substitution [m/s].
     """
-
     k_zero, mu_zero = std_functions.hashin_shtrikman_walpole(
         k1=k_cem,
         mu1=mu_cem,
@@ -224,55 +223,58 @@ def patchy_cement_model_cem_frac(
     npt.NDArray[np.float64],
 ]:
     """
-    Patchy cement model for sands that are a combination of friable model and constant cement model. No fluid or
-    pressure substitution. In this implementation of the patchy cement model the given cement fraction for the constant
-    cement model defines the upper bound, and the effective pressure for the friable model defines the lower bound
+    Patchy cement model for sands that are a combination of friable model and constant cement model.
+
+    No fluid or pressure substitution. In this implementation of the patchy cement model the given cement fraction for the constant
+    cement model defines the upper bound, and the effective pressure for the friable model defines the lower bound.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement bulk density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure [Pa].
-    frac_cem : float
+    frac_cem
         Upper bound cement volume fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    coord_num_func : str
+    coord_num_func
         Indication if coordination number should be calculated from porosity or kept constant, either "ConstVal" or
         "PoreBased" [default]
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor for sandstone [fraction].
 
     Returns
     -------
-    tuple
-        vp, vs, rhob, ai, vpvs : np.ndarray.
-        vp :Saturated P-velocity [m/s] after fluid and pressure substitution,
-        vs : Saturated S-velocity [m/s] after fluid and pressure substitution,
-        rhob : Saturated density [kg/m3] after fluid and pressure substitution,
-        ai : Saturated rock acoustic impedance [kg/m3 * m/s] after fluid and pressure substitution,
-        vpvs : Saturated rock velocity ratio [ratio].
+    vp
+        Saturated P-velocity after fluid and pressure substitution [m/s].
+    vs
+        Saturated S-velocity after fluid and pressure substitution [m/s].
+    rhob
+        Saturated density after fluid and pressure substitution [kg/m^3].
+    ai
+        Saturated rock acoustic impedance after fluid and pressure substitution [kg/m^3 x m/s].
+    vpvs
+        Saturated rock velocity ratio [ratio].
     """
-
     k_dry, mu, _ = patchy_cement_model_dry(
         k_min=k_min,
         mu_min=mu_min,
@@ -327,47 +329,49 @@ def patchy_cement_model_dry(
     shear_red: float,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Patchy cement model for sands that are a combination of friable model and constant cement model. No fluid or
-    pressure substitution. In this implementation of the patchy cement model the given cement fraction for the constant
-    cement model defines the upper bound, and the effective pressure for the friable model defines the lower bound
+    Patchy cement model for sands that are a combination of friable model and constant cement model.
+
+    No fluid or pressure substitution. In this implementation of the patchy cement model the given cement fraction for the constant
+    cement model defines the upper bound, and the effective pressure for the friable model defines the lower bound.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Mineral bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Total porosity [fraction].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure [Pa].
-    frac_cem : float
+    frac_cem
         Upper bound cement volume fraction [fraction].
-    phi_c : float
+    phi_c
         Critical porosity [fraction].
-    coord_num_func : str
+    coord_num_func
         Indication if coordination number should be calculated from porosity or kept constant, either "ConstVal" or
         "PoreBased" [default]
-    n : float
+    n
         Coordination number [unitless].
-    shear_red : float
+    shear_red
         Shear reduction factor for sandstone [fraction].
 
     Returns
     -------
-    tuple
-        k:dry, mu, rho_dry : np.ndarray
-        k_dry: dry rock bulk modulus [Pa],
-        mu : dry rock shear modulus [Pa],
-        rho_dry : dry rock density [kg/m3].,
+    k_dry
+        Dry rock bulk modulus [Pa].
+    mu
+        Dry rock shear modulus [Pa].
+    rho_dry
+        Dry rock density [kg/m^3].
     """
     # There are cases which suffer from a lack of consistency check at this stage,
     # add dim_check_vector and filter input/output

--- a/src/rock_physics_open/sandstone_models/patchy_cement_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_optimisation.py
@@ -54,49 +54,48 @@ def patchy_cement_model_optimisation(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Cement bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Cement shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         Cement density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Cement density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [kg/m^3].
-    por : np.ndarray
+    por
         Inclusion porosity [ratio].
-    p_eff : np.ndarray
+    p_eff
         Effective pressure log [Pa].
-    vp : np.ndarray
+    vp
         Compressional velocity log [m/s].
-    vs : np.ndarray
+    vs
         Shear velocity log [m/s].
-    rhob : np.ndarray
+    rhob
         Bulk density log [kg/m^3].
-    phi_c : float
+    phi_c
         Critical porosity [fraction]
-    file_out_str : str
+    file_out_str
         Output file name (string) to store optimal parameters (pickle format).
-    display_results : bool
+    display_results
         Display optimal parameters in a window after run.
-    well_name : str
+    well_name
         Name of well to be displayed in info box title.
-    opt_params_only : bool
+    opt_params_only
         return parameters from optimisation only
+
     Returns
     -------
-    tuple
-        vp_mod, vs_mod, rho_mod, ai_mod, vpvs_mod - modelled logs,
-        vp_res, vs_res, rho_res - residual logs.
+    vp_mod, vs_mod, rho_mod, ai_mod, vpvs_mod - modelled logs,
+    vp_res, vs_res, rho_res - residual logs.
     """
-
     # Skip hardcoded Vp/Vs ratio
     def_vpvs = np.mean(vp / vs)
     # Set weight to vs to give vp and vs similar influence on optimisation

--- a/src/rock_physics_open/sandstone_models/unresolved_cemented_sandshale_models.py
+++ b/src/rock_physics_open/sandstone_models/unresolved_cemented_sandshale_models.py
@@ -45,69 +45,76 @@ def unresolved_constant_cement_sand_shale_model(
     npt.NDArray[np.float64],
 ]:
     """
-    Model for silisiclastic rocks with alternating layers of cemented sand and friable shale, and in which the layers
-    are not resolved by the investigating signal. Backus average is used to calculate the anisotropic effect of the
+    Model for siliciclastic rocks with alternating layers of cemented sand and friable shale, and in which the layers are not resolved by the investigating signal.
+
+    Backus average is used to calculate the anisotropic effect of the
     alternating layers.
 
     Parameters
     ----------
-    k_min_sst : np.ndarray
+    k_min_sst
         Sandstone matrix bulk modulus [Pa].
-    mu_min_sst : np.ndarray
+    mu_min_sst
         Sandstone matrix shear modulus [Pa].
-    rho_min_sst : np.ndarray
+    rho_min_sst
         Sandstone matrix bulk density [kg/m^3].
-    k_cem : np.ndarray
+    k_cem
         Sandstone cement bulk modulus [Pa].
-    mu_cem : np.ndarray
+    mu_cem
         Sandstone cement shear modulus [Pa].
-    rho_cem : np.ndarray
+    rho_cem
         Sandstone cement bulk density [kg/m^3].
-    k_mud : np.ndarray
+    k_mud
         Shale bulk modulus [Pa].
-    mu_mud : np.ndarray
+    mu_mud
         Shale shear modulus [Pa].
-    rho_mud : np.ndarray
+    rho_mud
         Shale bulk density [kg/m^3].
-    k_fl_sst : np.ndarray
+    k_fl_sst
         Fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_sst : np.ndarray
+    rho_fl_sst
         Fluid bulk density for sandstone fluid [kg/m^3].
-    k_fl_mud : np.ndarray
+    k_fl_mud
         Fluid bulk modulus for shale fluid [Pa].
-    rho_fl_mud : np.ndarray
+    rho_fl_mud
         Fluid bulk density for shale fluid[kg/m^3].
-    phi_sst : np.ndarray
+    phi_sst
         Sandstone porosity [fraction].
-    phi_mud : np.ndarray
+    phi_mud
         Shale porosity [fraction].
-    p_eff_mud : np.ndarray
+    p_eff_mud
         Effective pressure in mud [Pa].
-    shale_frac : np.ndarray
+    shale_frac
         Shale fraction [fraction].
-    frac_cem : float
+    frac_cem
         Cement volume fraction [fraction].
-    phi_c_sst : float
+    phi_c_sst
         Critical porosity for sandstone [fraction].
-    phi_c_mud : float
+    phi_c_mud
         Critical porosity for mud [fraction].
-    n_sst : float
+    n_sst
         Coordination number for sandstone [unitless].
-    n_mud : float
-        Coordination number for shale [unitless].
-    coord_num_func_mud : str
+    coord_num_func_mud
         Indication if coordination number should be calculated from porosity or kept constant for shale.
-    shear_red_sst : float
+    n_mud
+        Coordination number for shale [unitless].
+    shear_red_sst
         Shear reduction factor for sandstone [fraction].
-    shear_red_mud : float
+    shear_red_mud
         Shear reduction factor for mud [fraction].
 
     Returns
     -------
-    tuple
-        vpv, vsv, vph, vsh, rho : np.ndarray
-        vertical p-wave velocity, vertical shear-wave velocity, horizontal p-wave velocity, horizontal shear-wave
-        velocity (all [m/s]), bulk density [kg/m^3].
+    vpv
+        Vertical p-wave velocity [m/s].
+    vsv
+        Vertical shear-wave velocity [m/s].
+    vph
+        Horizontal p-wave velocity [m/s].
+    vsh
+        Horizontal shear-wave velocity [m/s].
+    rho
+        Bulk density [kg/m^3].
     """
     # Estimate the sand end member through the constant cement model
     vp_sst, vs_sst, rho_b_sst, _, _ = constant_cement_model(

--- a/src/rock_physics_open/sandstone_models/unresolved_friable_sandshale_models.py
+++ b/src/rock_physics_open/sandstone_models/unresolved_friable_sandshale_models.py
@@ -40,67 +40,73 @@ def unresolved_friable_sand_shale_model(
     npt.NDArray[np.float64],
 ]:
     """
-    Model for siliciclastic rocks with alternating layers of friable sand and shale, and in which the layers are not
-    resolved by the investigating signal. Backus average is used to calculate the anisotropic effect of the alternating
+    Model for siliciclastic rocks with alternating layers of friable sand and shale, and in which the layers are not  resolved by the investigating signal.
+
+    Backus average is used to calculate the anisotropic effect of the alternating
     layers.
 
     Parameters
     ----------
-    k_sst : np.ndarray
+    k_sst
         Sandstone bulk modulus [Pa].
-    mu_sst : np.ndarray
+    mu_sst
         Sandstone shear modulus [Pa].
-    rho_sst : np.ndarray
+    rho_sst
         Sandstone bulk density [kg/m^3].
-    k_mud : np.ndarray
+    k_mud
         Shale bulk modulus [Pa].
-    mu_mud : np.ndarray
+    mu_mud
         Shale shear modulus [Pa].
-    rho_mud : np.ndarray
+    rho_mud
         Shale bulk density [kg/m^3].
-    k_fl_sst : np.ndarray
+    k_fl_sst
         Fluid bulk modulus for sandstone fluid [Pa].
-    rho_fl_sst : np.ndarray
+    rho_fl_sst
         Fluid bulk density for sandstone fluid [kg/m^3].
-    k_fl_mud : np.ndarray
+    k_fl_mud
         Fluid bulk modulus for shale fluid [Pa].
-    rho_fl_mud : np.ndarray
+    rho_fl_mud
         Fluid bulk density for shale fluid [kg/m^3].
-    phi_sst : np.ndarray
+    phi_sst
         Sandstone porosity [fraction].
-    phi_mud : np.ndarray
+    phi_mud
         Shale porosity [fraction].
-    p_eff_sst : np.ndarray
+    p_eff_sst
         Effective pressure in sandstone [Pa].
-    p_eff_mud : np.ndarray
+    p_eff_mud
         Effective pressure in mud [Pa].
-    shale_frac : np.ndarray
+    shale_frac
         Shale fraction [fraction].
-    phi_c_sst : float
+    phi_c_sst
         Critical porosity for sandstone [fraction].
-    phi_c_mud : float
+    phi_c_mud
         Critical porosity for mud [fraction].
-    coord_num_func_sst : str
+    coord_num_func_sst
         Indication if coordination number should be calculated from porosity or kept constant for sandstone.
-    n_sst : float
+    n_sst
         Coordination number for sandstone [unitless].
-    coord_num_func_mud : str
+    coord_num_func_mud
         Indication if coordination number should be calculated from porosity or kept constant for shale.
-    n_mud : float
+    n_mud
         Coordination number for shale [unitless].
-    shear_red_sst : float
+    shear_red_sst
         Shear reduction factor for sandstone [fraction].
-    shear_red_mud : float
+    shear_red_mud
         Shear reduction factor for mud [fraction].
 
     Returns
     -------
-    tuple
-        vpv, vsv, vph, vsh, rho : np.ndarray
-        vertical p-wave velocity, vertical shear-wave velocity, horizontal p-wave velocity, horizontal shear-wave
-        velocity (all [m/s]), bulk density [kg/m^3].
+    vpv
+        Vertical p-wave velocity [m/s].
+    vsv
+        Vertical shear-wave velocity [m/s].
+    vph
+        Horizontal p-wave velocity [m/s].
+    vsh
+        Horizontal shear-wave velocity [m/s].
+    rho
+        Bulk density [kg/m^3].
     """
-
     # Estimate the sand and shale end members through the friable models
     vp_sst, vs_sst, rho_b_sst, _, _ = friable_model(
         k_min=k_sst,

--- a/src/rock_physics_open/shale_models/dem.py
+++ b/src/rock_physics_open/shale_models/dem.py
@@ -23,37 +23,40 @@ def dem_model(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of background matrix [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of background matrix [Pa].
-    rho1 : np.ndarray
+    rho1
         Bulk density of background matrix [kg/m^3].
-    k2 : np.ndarray
+    k2
         Bulk modulus of inclusions [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of inclusions [Pa].
-    rho2 : np.ndarray
+    rho2
         Bulk density of inclusions [kg/m^3].
-    frac2 : np.ndarray
+    frac2
         Fraction of inclusions [fraction].
-    asp2 : np.ndarray
+    asp2
         Aspect ratio of inclusions [ratio].
-    tol: float
+    tol
         Desired accuracy in the ODE solver.
 
     Returns
     -------
-    tuple
-        k, mu, rho : np.ndarray
-        k: effective medium bulk modulus [Pa], mu: effective medium shear modulus [Pa], rho: bulk density [kg/m^3].
+    k
+        Effective medium bulk modulus [Pa].
+    mu
+        Effective medium shear modulus [Pa].
+    rhob
+        Bulk density [kg/m^3].
 
-    Comments
-    --------
+
+    Notes
+    -----
     Written by T. Mukerji, SRB, Stanford University.
     Ported to Python by Harald Flesche, Equinor 2015.
     """
-
     # Make sure all log inputs are vectors, expand scalars, throw error if uneven
     # length and not scalars
     k = np.ones(k1.shape) * np.nan
@@ -159,24 +162,23 @@ def _demy_prime(
 
     Parameters
     ----------
-    y : np.ndarray
+    y
         y array.
-    t : float
+    t
         t float.
-    k2 : np.ndarray
+    k2
         Bulk modulus of inclusions [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of inclusions [Pa].
-    asp2 : np.ndarray
+    asp2
         Aspect ratio of inclusions [ratio].
 
     Returns
     -------
-    np.ndarray
-        k, mu array.
+    Concatenated k, mu array.
 
-    Comments
-    --------
+    Notes
+    -----
     Written by T. Mukerji, Stanford University.
     Rewritten in Python by Harald Flesche, Equinor 2015.
     """

--- a/src/rock_physics_open/shale_models/dem_dual_por.py
+++ b/src/rock_physics_open/shale_models/dem_dual_por.py
@@ -24,40 +24,43 @@ def dem_model_dual_por(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Matrix bulk modulus [Pa].
-    mu1 : np.ndarray
+    mu1
         Matrix shear modulus [Pa].
-    rho1 : np.ndarray
+    rho1
         Matrix bulk density [kg/m^3].
-    k2 : np.ndarray
+    k2
         Inclusion 1 bulk modulus [Pa].
-    mu2 : np.ndarray
+    mu2
         Inclusion 1 shear modulus [Pa].
-    rho2 : np.ndarray
+    rho2
         Inclusion 1 bulk density [kg/m^3]
-    k3 : np.ndarray
+    k3
         Inclusion 2 bulk modulus [Pa].
-    mu3 : np.ndarray
+    mu3
         Inclusion 2 shear modulus [Pa].
-    rho3 : np.ndarray
+    rho3
         Inclusion 2 bulk density [kg/m^3].
-    frac_inc : np.ndarray
+    frac_inc
         Total fraction of inclusions [fraction].
-    frac_inc_1 : np.ndarray
+    frac_inc_1
         Fraction of inclusions belonging to type 1 [fraction].
-    asp_1 : np.ndarray
+    asp_1
         Aspect ratio of inclusion 1 [fraction].
-    asp_2 : np.ndarray
+    asp_2
         Aspect ratio of inclusion 2 [fraction].
-    tol : float
+    tol
         Tolerance of accuracy [unitless].
 
     Returns
     -------
-    tuple
-        k_dem_dual, mu_dem_dual, rhob_dem_dual : np.ndarray
-        k_dem_dual: bulk modulus [Pa], mu_dem_dual: shear modulus [Pa], rhob_dem_dual: bulk density [kg/m^3].
+    k_dem_dual
+        Bulk modulus [Pa].
+    mu_dem_dual
+        Shear modulus [Pa].
+    rhob_dem_dual
+        Bulk density [kg/m^3].
     """
     # Include the Type 1 inclusions into the matrix first, then run again with inclusions Type 2
     k_dem1, mu_dem1, rhob_dem1 = dem_model(

--- a/src/rock_physics_open/shale_models/kus_tok.py
+++ b/src/rock_physics_open/shale_models/kus_tok.py
@@ -20,28 +20,31 @@ def kuster_toksoz_model(
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Phase 1 bulk modulus [Pa].
-    mu1 : np.ndarray
+    mu1
         Phase 1 shear modulus [Pa].
-    rho1 : np.ndarray
+    rho1
         Phase 1 bulk density [kg/m^3].
-    k2 : np.ndarray
+    k2
         Phase 2 bulk modulus [Pa].
-    mu2 : np.ndarray
+    mu2
         Phase 2 shear modulus [Pa].
-    rho2 : np.ndarray
+    rho2
         Phase 2 bulk density [kg/m^3].
-    frac1 : np.ndarray
+    frac1
         Fraction of phase 1 [fraction].
-    asp2 : np.ndarray
+    asp2
         Aspect ratio for phase 2 inclusions [ratio].
 
     Returns
     -------
-    tuple
-        k_kt, mu_kt, rhob : np.ndarray
-        effective media properties: k_kt: bulk modulus [Pa], mu_kt: shear modulus [Pa], rhob: bulk density [kg/m^3].
+    k_kt
+        Effective bulk modulus [Pa].
+    mu_kt
+        Effective shear modulus [Pa].
+    rhob
+        Effective bulk density [kg/m^3].
     """
     frac2 = 1.0 - frac1
     rhob = rho1 * frac1 + rho2 * frac2

--- a/src/rock_physics_open/shale_models/multi_sca.py
+++ b/src/rock_physics_open/shale_models/multi_sca.py
@@ -16,8 +16,7 @@ def multi_sca(
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
 ]:
-    """SCA - Effective elastic moduli using Berryman's Self-Consistent
-    (Coherent Potential Approximation) method.
+    """SCA - Effective elastic moduli using Berryman's Self-Consistent (Coherent Potential Approximation) method.
 
     -----------------------------------------------
 
@@ -47,16 +46,20 @@ def multi_sca(
 
     Parameters
     ----------
-    args : list or tuple
+    *args
         List or tuple containing multiples of elastic properties as explained above, all numpy arrays.
-    tol : float
+    tol
         Tolerance for the SCA iterations.
 
     Returns
     -------
-    tuple
-        k_sc, mu_sc, rhob : (np.ndarray, np.ndarray, np.ndarray).
-        effective medium properties k_sc: bulk modulus [Pa], mu_sc: shear modulus [Pa], rhob: bulk density [kg/m^3].
+    k_sc
+        Effective bulk modulus [Pa].
+    mu_sc
+        Effective shear modulus [Pa].
+    rhob
+        Effective density [kg/m^3].
+
     """
     if len(args) % 5 != 0:
         raise ValueError(

--- a/src/rock_physics_open/shale_models/pq.py
+++ b/src/rock_physics_open/shale_models/pq.py
@@ -12,30 +12,30 @@ def p_q_fcn(
     """
     Geometric factors used in inclusion models.
 
-    References
-    ----------
-    The rock physics handbook, Gary Mavko et al.
-
     Parameters
     ----------
-    k : np.ndarray
+    k
         Bulk modulus of phase 1 [Pa].
-    mu : np.ndarray
+    mu
         Shear modulus of phase 1 [Pa].
-    k2 : np.ndarray
+    k2
         Bulk modulus of phase 2 [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of phase 2 [Pa].
-    asp : np.ndarray
+    asp
         Aspect ratio [ratio].
 
     Returns
     -------
-    tuple
-        p, q : np.ndarray
-        geometric factors p and q.
-    """
+    p
+        Geometric factor p.
+    q
+        Geometric factor q.
 
+    References
+    ----------
+    The rock physics handbook, Gary Mavko et al.
+    """
     # Functions theta and fn defaults to 2/3 and -2/5 for asp == 1.0
     idx_oblate = np.less(asp, 1.0)
     idx_prolate = np.greater(asp, 1.0)

--- a/src/rock_physics_open/shale_models/sca.py
+++ b/src/rock_physics_open/shale_models/sca.py
@@ -17,44 +17,45 @@ def self_consistent_approximation_model(
     tol: float,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    SCA - Effective elastic moduli using Berryman's Self-Consistent
-    (Coherent Potential) Approximation method.
+    SCA - Effective elastic moduli using Berryman's Self-Consistent (Coherent Potential) Approximation method.
 
     Parameters
     ----------
-    k1 : np.ndarray
+    k1
         Bulk modulus of background matrix [Pa].
-    mu1 : np.ndarray
+    mu1
         Shear modulus of background matrix [Pa].
-    rho1 : np.ndarray
+    rho1
         Bulk density of background matrix [kg/m^3].
-    k2 : np.ndarray
+    k2
         Bulk modulus of inclusions [Pa].
-    mu2 : np.ndarray
+    mu2
         Shear modulus of inclusions [Pa].
-    rho2 : np.ndarray
+    rho2
         Bulk density of inclusions [kg/m^3].
-    frac1 : np.ndarray
+    frac1
         Fraction of inclusions [fraction].
-    asp1 : np.ndarray
+    asp1
         Aspect ratio of background matrix [ratio].
-    asp2 : np.ndarray
+    asp2
         Aspect ratio of inclusions [ratio].
-    tol: float
+    tol
         Desired accuracy in the SCA iterations.
 
     Returns
     -------
-    tuple
-        k, mu, rho : np.ndarray
-        k: effective medium bulk modulus [Pa], mu: effective medium shear modulus [Pa], rho: bulk density [kg/m^3].
+    k
+        Effective medium bulk modulus [Pa].
+    mu
+        Effective medium shear modulus [Pa].
+    rho
+        Bulk density [kg/m^3].
 
-    Comments
-    --------
+    Notes
+    -----
     Based on function by T. Mukerji, SRB, Stanford University, 1994.
     Ported to Python by Harald Flesche, Equinor 2015.
     """
-
     # Calculate fn and theta - independent of iteration
     f1 = frac1
     f2 = 1 - frac1

--- a/src/rock_physics_open/shale_models/shale4_mineral.py
+++ b/src/rock_physics_open/shale_models/shale4_mineral.py
@@ -45,56 +45,86 @@ def shale_model_4_mineral_dem(
     npt.NDArray[np.float64],
 ]:
     """
-    Simple shale model with mixture of matrix minerals in self-consistent approximation
-    or Voigt-Reuss-Hill average. In the latter case the aspect ratios are ignored.
+    Simple shale model with mixture of matrix minerals in self-consistent approximation or Voigt-Reuss-Hill average.
+
+    In the latter case the aspect ratios are ignored.
     Fluid filled porosity is included through a DEM inclusion model.
 
     All k, mu inputs have unit [Pa], all rho inputs have unit [kg/m^3], phi and all f and asp have unit [fraction].
 
     Parameters
     ----------
-    k1, mu1, rho1 : np.ndarray
+    k1
         Mineral 1 properties [Quartz and feldspar].
-    k2, mu2, rho2 : np.ndarray
+    mu1
+        Mineral 1 properties [Quartz and feldspar].
+    rho1
+        Mineral 1 properties [Quartz and feldspar].
+    k2
         Mineral 2 properties [Kerogen].
-    k3, mu3, rho3 : np.ndarray
+    mu2
+        Mineral 2 properties [Kerogen].
+    rho2
+        Mineral 2 properties [Kerogen].
+    k3
         Mineral 3 properties [Clay].
-    k4, mu4, rho4 : np.ndarray
+    mu3
+        Mineral 3 properties [Clay].
+    rho3
+        Mineral 3 properties [Clay].
+    k4
         Mineral 4 properties [Carbonates].
-    k_fl, rho_fl : np.ndarray
+    mu4
+        Mineral 4 properties [Carbonates].
+    rho4
+        Mineral 4 properties [Carbonates].
+    k_fl
         Fluid properties.
-    phi : np.ndarray
+    rho_fl
+        Fluid properties.
+    phi
         Phi parameter.
-    f1 : np.ndarray
+    f1
         Fraction of mineral 1.
-    f2 : np.ndarray
+    f2
         Fraction of mineral 2.
-    f3 : np.ndarray
+    f3
         Fraction of mineral 3.
-    rhob_inp : np.ndarray
+    rhob_inp
         Observed density [kg/m^3].
-    asp1 : np.ndarray
+    asp1
         Aspect ratio mineral 1 inclusions.
-    asp2 : np.ndarray
+    asp2
         Aspect ratio mineral 2 inclusions.
-    asp3 : np.ndarray
+    asp3
         Aspect ratio mineral 3 inclusions.
-    asp4 : np.ndarray
+    asp4
         Aspect ratio mineral 4 inclusions.
-    asp : np.ndarray
+    asp
         Porosity aspect ratio.
-    mod_type : str
+    mod_type
         One of 'SCA' or 'VRH'.
 
     Returns
     -------
-    tuple
-        k, mu, rhob, vp, vs, rho_factor : (np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray).
-        k - effective bulk modulus [Pa], mu - effective shear modulus [Pa], rhob - effective density [kg/m^3],
-        vp - p-wave velocity [m/s], vs - shear wave velocity [m/s], rho_factor - ratio between modelled and observed
-        density [ratio].
-    """
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
+    rhob
+        Effective density [kg/m^3].
+    vp
+        P-wave velocity [m/s].
+    vs
+        Shear wave velocity [m/s].
+    rho_factor
+        Ratio between modelled and observed density [ratio].
 
+    Raises
+    ------
+    ValueError
+        If mod_type is unknown.
+    """
     #   tol: DEM model calculation tolerance <= Set as a hardcoded value, not
     #   found to influence the results
     tol = 1.0e-6

--- a/src/rock_physics_open/shale_models/shale4_mineral_dem_overlay.py
+++ b/src/rock_physics_open/shale_models/shale4_mineral_dem_overlay.py
@@ -31,43 +31,67 @@ def shale_4_min_dem_overlay(
     asp: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
-    Simple shale model with mixture of matrix minerals in Voigt-Reuss-Hill
-    and DEM inclusion model for fluid filled porosity. The model is aimed at
-    overlays in cross-plots where two input fractions are given, and the two
-    remaining are given as a proportion.
+    Simple shale model with mixture of matrix minerals in Voigt-Reuss-Hill and DEM inclusion model for fluid filled porosity.
+
+    The model is aimed at overlays in cross-plots where two input fractions are given, and the two remaining are given as a proportion.
     Fraction of carbonate and clay is implicit 1 - f1 - f2. f1 and f2 can be set to zero
     All k, mu values in [Pa], rho in [kg/m^3], f, phi, prop_clay, asp in [fraction].
 
     Parameters
     ----------
-    k1, mu1, rho1 : np.ndarray
+    k1
         Mineral 1 properties [Quartz and feldspar].
-    k2, mu2, rho2 : np.ndarray
+    mu1
+        Mineral 1 properties [Quartz and feldspar].
+    rho1
+        Mineral 1 properties [Quartz and feldspar].
+    k2
         Mineral 2 properties [Kerogen].
-    k3, mu3, rho3 : np.ndarray
+    mu2
+        Mineral 2 properties [Kerogen].
+    rho2
+        Mineral 2 properties [Kerogen].
+    k3
         Mineral 3 properties [Clay].
-    k4, mu4, rho4 : np.ndarray
+    mu3
+        Mineral 3 properties [Clay].
+    rho3
+        Mineral 3 properties [Clay].
+    k4
         Mineral 4 properties [Carbonates].
-    k_fl, rho_fl : np.ndarray
+    mu4
+        Mineral 4 properties [Carbonates].
+    rho4
+        Mineral 4 properties [Carbonates].
+    k_fl
         Fluid properties.
-    phi : np.ndarray
+    rho_fl
+        Fluid properties.
+    phi
         Porosity.
-    f1 : np.ndarray
+    f1
         Fraction of mineral 1.
-    f2 : np.ndarray
+    f2
         Fraction of mineral 2.
-    prop_clay : float
+    prop_clay
         Range 0 - 1 of the fraction that is clay and carbonate.
-    asp: np.ndarray
+    asp
         Porosity aspect ratio.
 
     Returns
     -------
-    tuple
-        k, mu, rhob : np.ndarray
-        k - effective bulk modulus [Pa], mu - effective shear modulus [Pa], rhob - effective density [kg/m^3].
-    """
+    k
+        Effective bulk modulus [Pa].
+    mu
+        Effective shear modulus [Pa].
+    rhob
+        Effective density [kg/m^3].
 
+    Raises
+    ------
+    ValueError
+        If sum of fixed mineral fractions exceeds 1.0 or if any fraction is negative.
+    """
     #   tol: DEM model calculation tolerance <= Set as a hardcoded value, not
     #   found to influence the results
     tol = 1e-6

--- a/src/rock_physics_open/span_wagner/co2_properties.py
+++ b/src/rock_physics_open/span_wagner/co2_properties.py
@@ -37,25 +37,29 @@ def co2_properties(
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
     CO2 properties are estimated according to Span & Wagner's equation of state model.
+
+    Parameters
+    ----------
+    temp
+        Temperature [°C]
+    pres
+        Pressure [Pa]
+
+    Returns
+    -------
+    vel_co2
+        CO2 velocity [m/s].
+    den_co2
+        CO2 density [kg/m^3].
+    k_co2
+        CO2 bulk modulus [Pa].
+
     References
     ----------
     R. Span and W. Wagner: A new equation of state for carbon dioxide covering the
     fluid region from the triple point temperature to 1100K at pressures up to
     800 MPa.
     J. Phys. Chem. Ref. Data, Vol. 25, No. 6, 1996, pp 1509 - 1596
-
-    Parameters
-    ----------
-    temp: np.ndarray
-        Temperature [°C]
-    pres: np.ndarray
-        Pressure [Pa]
-
-    Returns
-    -------
-    tuple
-        vel_co2, den_co2, k_co2 : (np.ndarray, np.ndarray, np.ndarray).
-        vel_co2: velocity [m/s], den_co2: density [kg/m^3], k_co2: bulk modulus [Pa].
     """
     abs_temp = celsius_to_kelvin(temp)
     pres_mpa = pres * 1.0e-6
@@ -73,12 +77,22 @@ def co2_helmholtz_energy(
     dt: Literal[0, 1, 2],
 ) -> npt.NDArray[np.float64] | float:
     """
-    Helmholtz energy as defined by equation 6.1 in Span & Wagner [2]
+    Helmholtz energy as defined by equation 6.1 in Span & Wagner [2].
 
-    :param delta: Reduced density, unit-less. That is, density / CO2_CRITICAL_DENSITY.
-    :param tau: Inverse reduced temperature, unit-less. That is, CO2_CRITICAL_TEMPERATURE / (absolute) temperature
-    :param dd: Degree of derivation wrt. delta. Integer between 0 and 2.
-    :param dt: Degree of derivation wrt. tau. Integer between 0 and 2, as long as (dt + dd < 3)
+    Parameters
+    ----------
+    delta
+        Reduced density, unit-less. That is, density / CO2_CRITICAL_DENSITY.
+    tau
+        Inverse reduced temperature, unit-less. That is, CO2_CRITICAL_TEMPERATURE / (absolute) temperature
+    dd
+        Degree of derivation wrt. delta. Integer between 0 and 2.
+    dt
+        Degree of derivation wrt. tau. Integer between 0 and 2, as long as (dt + dd < 3)
+
+    Returns
+    -------
+    Result.
     """
     return ideal_gas_helmholtz_energy(
         delta=delta,
@@ -100,8 +114,25 @@ def ideal_gas_helmholtz_energy(
     dt: Literal[0, 1, 2],
 ) -> npt.NDArray[np.float64] | float:
     """
-    Helmholtz energy from ideal gas behavior as defined by equation 2.3 in Span & Wagner [2]. See function
-    co2_helmholtz_energy for argument documentation.
+    Helmholtz energy from ideal gas behavior as defined by equation 2.3 in Span & Wagner [2].
+
+    See function `co2_helmholtz_energy` for argument documentation.
+
+    Parameters
+    ----------
+    delta
+        Reduced density.
+    tau
+        Inverse reduced temperature.
+    dd
+        Degree of derivation wrt. density.
+    dt
+        Degree of derivation wrt. temperature.
+
+    Returns
+    -------
+    Result.
+
     """
     # Adjust array shapes
     tau = np.asarray(tau)
@@ -148,8 +179,24 @@ def co2_residual_helmholtz_energy(
     dt: Literal[0, 1, 2],
 ) -> npt.NDArray[np.float64] | float:
     """
-    Residual part of Helmholtz energy as defined by the equation in Table 32 of Span & Wagner [2]. See
-    co2_helmholtz_energy for argument documentation.
+    Residual part of Helmholtz energy as defined by the equation in Table 32 of Span & Wagner [2].
+
+    See `co2_helmholtz_energy` for argument documentation.
+
+    Parameters
+    ----------
+    delta
+        Reduced density.
+    tau
+        Inverse reduced temperature.
+    dd
+        Degree of derivation wrt. density.
+    dt
+        Degree of derivation wrt. temperature.
+
+    Returns
+    -------
+    Result.
     """
     tau = np.asarray(tau)
     delta = np.asarray(delta)
@@ -200,13 +247,29 @@ def carbon_dioxide_pressure(
     isentropic: bool = False,
 ) -> npt.NDArray[np.float64] | None:
     """
-    CO2 pressure (MPa) as given by Table 3 of Span & Wagner [2]
+    CO2 pressure (MPa) as given by Table 3 of Span & Wagner [2].
 
-    :param absolute_temperature: Temperature in K.
-    :param density: CO2 density (kg / m^3).
-    :param d_density: Degree of derivation wrt. density.
-    :param d_temperature: Degree of derivation wrt. temperature.
-    :param isentropic: Correction for isentropic conditions. Relevant primarily for isentropic bulk modulus
+    Parameters
+    ----------
+    absolute_temperature
+        Temperature in K.
+    density
+        CO2 density (kg / m^3).
+    d_density
+        Degree of derivation wrt. density.
+    d_temperature
+        Degree of derivation wrt. temperature.
+    isentropic
+        Correction for isentropic conditions. Relevant primarily for isentropic bulk modulus
+
+    Returns
+    -------
+    Result.
+
+    Raises
+    ------
+    ValueError
+        If d_temperature must be 0, but was {d_temperature}.
     """
     tau = CO2_CRITICAL_TEMPERATURE / absolute_temperature
     delta = density / CO2_CRITICAL_DENSITY
@@ -286,10 +349,16 @@ def saturated_liquid_density(
     absolute_temperature: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Saturated liquid density as defined by equation 3.14 of Span & Wagner [2]
+    Saturated liquid density as defined by equation 3.14 of Span & Wagner [2].
 
-    :param absolute_temperature: Absolute temperature in K. Should satisfy:
-        CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature in K. Should satisfy: CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+
+    Returns
+    -------
+    Result.
     """
     _a1 = 1.9245108
     _a2 = -0.62385555
@@ -304,10 +373,16 @@ def saturated_vapor_density(
     absolute_temperature: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Saturated vapor density as defined by equation 3.15 of Span & Wagner
+    Saturated vapor density as defined by equation 3.15 of Span & Wagner.
 
-    :param absolute_temperature: Absolute temperature in K. Should satisfy:
-        CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature in K. Should satisfy: CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+
+    Returns
+    -------
+    Result.
     """
     # Assert temp < critical
     _a1 = -1.7074879
@@ -330,9 +405,16 @@ def sublimation_pressure(
     absolute_temperature: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Sublimation pressure as defined by equation 3.12 of Span & Wagner [2]
+    Sublimation pressure as defined by equation 3.12 of Span & Wagner [2].
 
-    :param absolute_temperature: Absolute temperature in K. Should satisfy absolute_temperature < CO2_TRIPLE_TEMPERATURE
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature in K. Should satisfy absolute_temperature < CO2_TRIPLE_TEMPERATURE
+
+    Returns
+    -------
+    Result.
     """
     _a1 = -14.740846
     _a2 = 2.4327015
@@ -346,10 +428,16 @@ def vapor_pressure(
     absolute_temperature: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Vapor pressure as defined by equation 3.13 of Span & Wagner [2]
+    Vapor pressure as defined by equation 3.13 of Span & Wagner [2].
 
-    :param absolute_temperature: Absolute temperature in K. Should satisfy:
-        CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature in K. Should satisfy: CO2_TRIPLE_TEMPERATURE < absolute_temperature < CO2_CRITICAL_TEMPERATURE
+
+    Returns
+    -------
+    Result.
     """
     _a1 = -7.0602087
     _a2 = 1.9391218
@@ -364,9 +452,16 @@ def melting_pressure(
     absolute_temperature: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Melting pressure as defined by equation 3.10 of Span & Wagner [2]
+    Melting pressure as defined by equation 3.10 of Span & Wagner [2].
 
-    :param absolute_temperature: Absolute temperature in K. Should satisfy CO2_TRIPLE_TEMPERATURE < absolute_temperature
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature in K. Should satisfy CO2_TRIPLE_TEMPERATURE < absolute_temperature
+
+    Returns
+    -------
+    Result.
     """
     _a1 = 1955.5390
     _a2 = 2055.4593
@@ -379,9 +474,7 @@ def _determine_density_bounds(
     pressure: npt.NDArray[np.float64],
     force_vapor: bool | Literal["auto"],
 ) -> Array2D[np.float64]:
-    """
-    Calculate the upper and lower bound on density
-    """
+    """Calculate the upper and lower bound on density."""
     bounds = np.zeros((absolute_temperature.size, 2))
     bounds[:, 0] = 0.1
     bounds[:, 1] = 1500.0
@@ -406,7 +499,9 @@ def _determine_density_bounds(
             below_critical
         ] < vapor_pressure(absolute_temperature[below_critical])
         is_vapor = below_critical & below_vapor_pressure
-        bounds[is_vapor, 1] = saturated_vapor_density(absolute_temperature[is_vapor])
+        bounds[is_vapor, 1] = saturated_vapor_density(
+            absolute_temperature=absolute_temperature[is_vapor]
+        )
         is_liquid = below_critical & ~below_vapor_pressure
         bounds[is_liquid, 0] = saturated_liquid_density(absolute_temperature[is_liquid])
     return bounds
@@ -418,10 +513,23 @@ def _find_initial_density_values(
     pressure: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """
-    Finds approximate density values for the provided temperature(s) and pressure(s). The result is only intended to be
-    used by array_carbon_dioxide_density.
-    """
+    Finds approximate density values for the provided temperature(s) and pressure(s).
 
+    The result is only intended to be used by `array_carbon_dioxide_density`.
+
+    Parameters
+    ----------
+    bounds
+        Density bounds.
+    absolute_temperature
+        Absolute temperature (K).
+    pressure
+        Pressure (MPa).
+
+    Returns
+    -------
+    Result.
+    """
     temps = np.geomspace(
         np.min(absolute_temperature) * 0.99, np.max(absolute_temperature) * 1.01, 41
     )
@@ -449,12 +557,26 @@ def array_carbon_dioxide_density(
     force_vapor: bool,
 ) -> npt.NDArray[np.float64]:
     """
-    Alternative implementation of a vectorized carbon dioxide density function. Implemented primarily for demonstration
-    purposes. For large arrays, a look-up-table approach should be preferred.
+    Alternative implementation of a vectorized carbon dioxide density function.
+
+    Implemented primarily for demonstration purposes. For large arrays, a look-up-table approach should be preferred.
 
     Utilizes scipy.optimize.newton, which is the only root-finding method of scipy that supports a vectorized functions.
 
     For argument documentation, see carbon_dioxide_density.
+
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature (K).
+    pressure
+        Pressure (MPa).
+    force_vapor
+        Whether to force vapor phase.
+
+    Returns
+    -------
+    Result.
     """
     absolute_temperature = np.asarray(absolute_temperature)
     pressure = np.asarray(pressure)
@@ -500,21 +622,28 @@ def _calculate_carbon_dioxide_density(
     raise_error: bool = True,
 ) -> npt.NDArray[np.float64]:
     """
-    Density of carbon dioxide. Found solving the Pressure equation of Table 3 in Span & Wagner [2] numerically for
-    density using a vectorized bisection method. To ensure a single solution, the phase of the liquid must first be
+    Density of carbon dioxide.
+
+    Found solving the Pressure equation of Table 3 in Span & Wagner [2] numerically for density using a vectorized bisection method.
+
+    To ensure a single solution, the phase of the liquid must first be
     determined.
 
-    :param absolute_temperature: Absolute temperature (K).
-    :param pressure: Pressure (MPa).
-    :param force_vapor: Boolean or 'auto'. If 'auto', the phase of the fluid is automatically determined. However, along
-        the vaporization line (assuming T_triple < absolute_temperature < T_critical), the fluid is in two-phase
-        equilibrium and the phase cannot be uniquely determined. If force_vapor is set to True, vapor phase is always
-        selected, if False, liquid phase is selected. Outside the temperature bounds, this argument has no effect. This
-        argument should only be used close to the vaporization boundary, otherwise the behavior might not be as
-        expected.
-    :param raise_error: Boolean. If True, raises an error if density cannot be determined. Otherwise, returns np.nan.
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature (K).
+    pressure
+        Pressure (MPa).
+    force_vapor
+        If 'auto', the phase of the fluid is automatically determined. However, along the vaporization line (assuming T_triple < absolute_temperature < T_critical), the fluid is in two-phase equilibrium and the phase cannot be uniquely determined. If force_vapor is set to True, vapor phase is always selected, if False, liquid phase is selected. Outside the temperature bounds, this argument has no effect. This argument should only be used close to the vaporization boundary, otherwise the behavior might not be as expected.
+    raise_error
+        If True, raises an error if density cannot be determined. Otherwise, returns np.nan.
 
-    :return: Density (kg / m^3)
+    Returns
+    -------
+    Density (kg / m^3)
+
     """
     absolute_temperature = np.atleast_1d(np.asarray(absolute_temperature, dtype=float))
     pressure = np.atleast_1d(np.asarray(pressure, dtype=float))
@@ -565,15 +694,23 @@ def carbon_dioxide_density(
     **kwargs: Any,
 ) -> npt.NDArray[np.float64]:
     """
-    Density of carbon dioxide. Found either by direct calculation or interpolation. Any additional arguments are passed
-    to _calculate_carbon_dioxide_density.
+    Density of carbon dioxide. Found either by direct calculation or interpolation.
 
-    :param absolute_temperature: Absolute temperature (K).
-    :param pressure: Pressure (MPa).
-    :param interpolate: Flag whether to interpolate data or not. If not, data is calculated directly. This is more
-        accurate, but also more time-consuming. Data outside the bounds of the interpolator will be set to np.nan.
+    Any additional arguments are passed to `_calculate_carbon_dioxide_density`.
 
-    :return: Density (kg / m^3)
+    Parameters
+    ----------
+    absolute_temperature
+        Absolute temperature (K).
+    pressure
+        Pressure (MPa).
+    interpolate
+        Flag whether to interpolate data or not. If not, data is calculated directly. This is more accurate, but also more time-consuming. Data outside the bounds of the interpolator will be set to np.nan.
+    **kwargs
+
+    Returns
+    -------
+    Density (kg / m^3)
     """
     if interpolate is False:
         return _calculate_carbon_dioxide_density(
@@ -597,9 +734,7 @@ def carbon_dioxide_bulk_modulus(
     absolute_temperature: npt.NDArray[np.float64],
     density: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
-    """
-    Isentropic bulk modulus, derived from the expression for speed of sound in Table 3 of Span & Wagner
-    """
+    """Isentropic bulk modulus, derived from the expression for speed of sound in Table 3 of Span & Wagner."""
     d_pressure = carbon_dioxide_pressure(
         absolute_temperature=absolute_temperature,
         density=density,

--- a/src/rock_physics_open/span_wagner/coefficients.py
+++ b/src/rock_physics_open/span_wagner/coefficients.py
@@ -1,5 +1,5 @@
 """
-Span-Wagner Coefficients
+Span-Wagner Coefficients.
 
 Coefficients defined in tables of Span & Wagner. Coefficients are divided into groups according to horizontal lines in
 the table. This is also convenient when evaluating the Helmholtz energy expressions (phi functions).

--- a/src/rock_physics_open/span_wagner/equations.py
+++ b/src/rock_physics_open/span_wagner/equations.py
@@ -242,7 +242,7 @@ def _s3_dd2_dt0(
 def _s4_bigdelta(
     tau: npt.NDArray[np.float64], delta: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
-    """bigdelta = theta^2 + B4*|delta-1|^(2*a4)"""
+    """Bigdelta = theta^2 + B4*|delta-1|^(2*a4)."""
     return (
         B4 * np.abs(delta - 1) ** (2 * a4)
         + (A4 * np.abs(delta - 1) ** (beta4 ** (-1.0)) - tau + 1) ** 2
@@ -252,7 +252,7 @@ def _s4_bigdelta(
 def _s4_phi(
     delta: npt.NDArray[np.float64], tau: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
-    """phi = exp(-C4*(delta-1)^2 - D4*(tau-1)^2)"""
+    """Phi = exp(-C4*(delta-1)^2 - D4*(tau-1)^2)."""
     return np.exp(-C4 * (delta - 1) ** 2 - D4 * (tau - 1) ** 2)
 
 
@@ -443,15 +443,25 @@ def residual_helmholtz_energy(
     diff_tau: int,
 ) -> npt.NDArray[np.float64]:
     """
-    Equation 6.1 from Span & Wagner [2]. Calculates the residual helmholtz energy of co2 or its derivatives. tau_ and
-    delta_ must have be numpy arrays of shape (N, 1). This allows for vectorization.
+    Equation 6.1 from Span & Wagner [2].
 
-    :param delta_: Reduced density. Unit-less. numpy.ndarray with shape (N, 1)
-    :param tau_: Inverse reduced temperature. Unit-less. numpy.ndarray with shape (N, 1)
-    :param diff_delta: Degree of derivation wrt. delta. Integer.
-    :param diff_tau: Degree of derivation wrt. tau. Integer.
+    Calculates the residual helmholtz energy of co2 or its derivatives.
+    tau_ and delta_ must have be numpy arrays of shape (N, 1). This allows for vectorization.
 
-    :return: Helmholtz free energy. Unit-less. numpy.ndarray with shape (N,)
+    Parameters
+    ----------
+    delta_
+        Reduced density. Unit-less. numpy.ndarray with shape (N, 1)
+    tau_
+        Inverse reduced temperature. Unit-less. numpy.ndarray with shape (N, 1)
+    diff_delta
+        Degree of derivation wrt. delta. Integer.
+    diff_tau
+        Degree of derivation wrt. tau. Integer.
+
+    Returns
+    -------
+    Helmholtz free energy. Unit-less. numpy.ndarray with shape (N,)
     """
     _s1 = np.sum(_EXPRESSIONS[(1, diff_delta, diff_tau)](tau_, delta_), axis=-1)
     _s2 = np.sum(_EXPRESSIONS[(2, diff_delta, diff_tau)](tau_, delta_), axis=-1)

--- a/src/rock_physics_open/t_matrix_models/carbonate_pressure_substitution.py
+++ b/src/rock_physics_open/t_matrix_models/carbonate_pressure_substitution.py
@@ -35,6 +35,7 @@ def carbonate_pressure_model(
 ]:
     """
     Function for estimating relative changes in Vp and Vs as a function of formation pressure depletion for carbonates.
+
     The models that are used are based on laboratory plug measurements at close to in situ conditions,
     and with simulated formation pressure depletion. The training and validation data set is based on pre-salt
     carbonates from producing fields from the Brazilian continental shelf.
@@ -48,47 +49,50 @@ def carbonate_pressure_model(
 
     Parameters
     ----------
-    rho_fluid : np.ndarray
+    rho_fluid
         Fluid density [kg/m^3]
-    vp_in_situ : np.ndarray
+    vp_in_situ
         In situ Vp [m/s]
-    vs_in_situ : np.ndarray
+    vs_in_situ
         In situ Vs [m/s]
-    rho_in_situ : np.ndarray
+    rho_in_situ
         In situ bulk density [kg/m^3]
-    vp_fluid_sub : np.ndarray
+    vp_fluid_sub
         Fluid substituted Vp [m/s]
-    vs_fluid_sub : np.ndarray
+    vs_fluid_sub
         Fluid substituted Vs [m/s]
-    rho_fluid_sub : np.ndarray
+    rho_fluid_sub
         Fluid substituted bulk density [kg/m^3]
-    phi : np.ndarray
+    phi
         Porosity [fraction]
-    pres_overburden : np.ndarray
+    pres_overburden
         Overburden pressure [Pa]
-    pres_formation : np.ndarray
+    pres_formation
         In situ formation pressure [Pa]
-    pres_form_depleted : np.ndarray
+    pres_form_depleted
         Depleted formation pressure [Pa]
-    vp_model : Path
+    vp_model
         Full name to neural network model for Vp
-    vs_model : Path
+    vs_model
         Full name to neural network model for Vs
-    model_path : Path
+    model_path
         Path to model directory
-    b_add_fluid_sub : bool
+    b_add_fluid_sub
         Control whether effect of fluid substitution should be added to the final result
 
     Returns
     -------
-    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-        vp_pres_sub : pressure substituted p-velocity [m/s]
-        vs_pres_sub : pressure substituted s-velocity [m/s]
-        rho_pres_sub : fluid substituted density is returned as the pressure substitution does not change this [kg/m^3]
-        ai_pres_sub : derived acoustic impedance [m/s x kg/m^3]
-        vpvs_pres_sub : derived vp/vs-ratio [fraction]
+    vp_pres_sub
+        Pressure substituted p-velocity [m/s].
+    vs_pres_sub
+        Pressure substituted s-velocity [m/s].
+    rho_pres_sub
+        Fluid substituted density (unchanged by pressure substitution) [kg/m^3].
+    ai_pres_sub
+        Derived acoustic impedance [m/s x kg/m^3].
+    vpvs_pres_sub
+        Derived Vp/Vs ratio [fraction].
     """
-
     # Plug measurements are reported or dry rock density, bulk density needs to be corrected for fluid effect
     rho_dry = rho_in_situ - rho_fluid * phi
 

--- a/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_exp.py
+++ b/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_exp.py
@@ -25,42 +25,42 @@ def curvefit_t_matrix_exp(
     mu_sh: float,
     rho_sh: float,
 ) -> Array1D[np.float64]:
-    """Optimisation of input parameters to T-Matrix for carbonate in case where the mineral composition for each
-    sample is not known, so that effective mineral moduli for each sample are part of the parameters to be optimised
+    """Optimisation of input parameters to T-Matrix for carbonate.
+
+    Used in cases where the mineral composition for each sample is not known, so that effective mineral moduli for each sample are part of the parameters to be optimised
     for. The optimisation is also made for the inclusion parameters in addition to fraction of connected and anisotropic
     porosity and the VTI plane angle.
 
     Parameters
     ----------
-    x_data : np.ndarray
+    x_data
         Inputs to unpack.
-    frac_ani : float
+    frac_ani
         Fraction of anisotropic inclusions.
-    frac_con : float
+    frac_con
         Fraction of connected inclusions.
-    alpha1 : float
+    alpha1
         Aspect ratio of first inclusion set.
-    alpha2 : float
+    alpha2
         Aspect ratio of second inclusion set.
-    v1 : float
+    v1
         Concentration ratio of first inclusion set.
-    k_c : float
+    k_c
         p-wave velocity for carbonate matrix.
-    mu_c : float
+    mu_c
         vp/vs ratio for carbonate matrix.
-    rho_c : float
+    rho_c
         vp/vs ratio for carbonate matrix.
-    k_sh : float
+    k_sh
         p-wave velocity for shale.
-    mu_sh : float
+    mu_sh
         vp/vs ratio for shale.
-    rho_sh : float
+    rho_sh
         Density for shale.
 
     Returns
     -------
-    np.ndarray
-        Modelled velocity, vp and vs.
+    Modelled velocity, vp and vs.
     """
     # Restore original value range for parameters - must match the scaling performed in calling function
     _, scale_val, _ = opt_param_info()

--- a/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_min.py
+++ b/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_min.py
@@ -13,30 +13,34 @@ def curve_fit_2_inclusion_sets(
     alpha2: float,
     v1: float,
 ) -> Array1D[np.float64]:
-    """Optimisation of input parameters to T-Matrix for carbonate in case where the mineral composition for each
-    sample is known, so that effective mineral moduli for each sample are part of the inputs. The optimisation
-    is made for the inclusion parameters in addition to fraction of connected and anisotropic porosity and the
-    VTI plane angle.
+    """Optimisation of input parameters to T-Matrix for carbonate.
+
+    Used in cases where the mineral composition for each sample is known, so that effective mineral moduli for each sample are part of the inputs.
+    The optimisation is made for the inclusion parameters in addition to fraction of connected and anisotropic porosity and the VTI plane angle.
 
     Parameters
     ----------
-    x_data : np.ndarray
+    x_data
         Inputs to unpack.
-    frac_ani : float
+    frac_ani
         Fraction of anisotropic inclusions.
-    frac_con : float
+    frac_con
         Fraction of connected inclusions.
-    alpha1 : float
+    alpha1
         Aspect ratio of first inclusion set.
-    alpha2 : float
+    alpha2
         Aspect ratio of second inclusion set.
-    v1 : float
+    v1
         Concentration ratio of first inclusion set.
 
     Returns
     -------
-    np.ndarray
-        Modelled velocity.
+    Modelled velocity.
+
+    Raises
+    ------
+    ValueError
+        If alpha 1 is lower than alpha 2, and v1 is not a positive fraction
     """
     # Unpack x inputs
     # In calling function:

--- a/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
+++ b/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
@@ -53,52 +53,94 @@ def parse_t_matrix_inputs(
     Literal[0, 1, 2],
     Literal[0, 1, 2],
 ]:
-    """Function to do all necessary checking of input type, dimension, reshaping etc. that clutter up the start of T-Matrix
+    """Function to do all necessary checking of input type, dimension, reshaping etc. that clutter up the start of T-Matrix.
+
     NB: Setting scenario will override the settings for alpha, v and tau.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         N length numpy array, mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         N length numpy array, mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         N length numpy array, mineral density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         N length numpy array, fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
-        N length numpy array, mineral density [kg/m^3].
-    phi : np.ndarray or float
+    rho_fl
+        N length numpy array, fluid density [kg/m^3].
+    phi
         N length numpy array, total porosity [ratio].
-    perm : np.ndarray or float
+    perm
         float or N length numpy array, permeability [mD].
-    visco : np.ndarray or float
+    visco
         float or N length numpy array, fluid viscosity [cP].
-    alpha : np.ndarray
+    alpha
         M or NxM length numpy array, inclusion aspect ratio [ratio].
-    v : np.ndarray
+    v
         M or NxM length numpy array, inclusion concentration [ratio].
-    tau : np.ndarray
+    tau
         M length numpy array, relaxation time [s].
-    frequency : float
+    frequency
         single float, signal frequency [Hz].
-    angle : float
+    angle
         single float, angle of symmetry plane [degree].
-    frac_inc_con : np.ndarray or float
+    frac_inc_con
         single float or N length numpy array, fraction of connected inclusions [ratio].
-    frac_inc_ani : np.ndarray or float
+    frac_inc_ani
         single float or N length numpy array, fraction of anisotropic inclusions [ratio].
-    pressure : list or np.ndarray
+    pressure
          > 1 value list or numpy array in ascending order, effective pressure [Pa].
-    scenario : int
+    scenario
         pre-set scenarios for alpha, v and tau
-    fcn : callable | str | None.
+    fcn
         function with which to run the T-Matrix model or string with function name within t_matrix_models. If None, the C++ implementation is used.
 
     Returns
     -------
-    tuple
-        All inputs in correct dimension and data type plus ctrl_connected, ctrl_anisotropy - control parameters.
+    k_min
+        Mineral bulk modulus, validated and reshaped [Pa].
+    mu_min
+        Mineral shear modulus, validated and reshaped [Pa].
+    rho_min
+        Mineral density, validated and reshaped [kg/m^3].
+    k_fl
+        Fluid bulk modulus, validated and reshaped [Pa].
+    rho_fl
+        Fluid density, validated and reshaped [kg/m^3].
+    phi
+        Porosity, validated and reshaped [fraction].
+    perm
+        Permeability, validated and reshaped.
+    visco
+        Viscosity, validated and reshaped.
+    tau
+        Relaxation time array, validated and reshaped.
+    alpha
+        Aspect ratios, validated and reshaped.
+    v
+        Inclusion volumes, validated and reshaped.
+    frequency
+        Frequency value.
+    angle
+        Incidence angle value.
+    frac_inc_con
+        Connected inclusion fraction, validated and reshaped.
+    frac_inc_ani
+        Anisotropic inclusion fraction, validated and reshaped.
+    pressure
+        Pressure, validated and reshaped (or None if unused).
+    t_matrix_fcn
+        Resolved T-Matrix callable.
+    ctrl_connected
+        Control parameter for connected inclusions (0, 1 or 2).
+    ctrl_anisotropy
+        Control parameter for anisotropic inclusions (0, 1 or 2).
+
+    Raises
+    ------
+    ValueError
+        If inputs have wrong type, dimension, or invalid values.
     """
 
     def _assert_type(
@@ -110,11 +152,11 @@ def parse_t_matrix_inputs(
 
         Parameters
         ----------
-        arg : any
+        arg
             To be asserted.
-        exp_dtype : type
+        exp_dtype
             Expected data type.
-        err_str : str, optional
+        err_str
             Error string, by default 'check inputs, wrong type encountered'.
 
         Raises

--- a/src/rock_physics_open/t_matrix_models/run_t_matrix.py
+++ b/src/rock_physics_open/t_matrix_models/run_t_matrix.py
@@ -93,51 +93,58 @@ def run_t_matrix(
     ]
 ):
     """Function to run T-Matrix in different flavours, with or without pressure steps included.
+
     A frontend to running T-Matrix model, including testing of all input parameters in the parse_t_matrix_inputs.
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         N length numpy array, mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         N length numpy array, mineral shear modulus [Pa].
-    rho_min : np.ndarray
+    rho_min
         N length numpy array, mineral density [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         N length numpy array, fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
-        N length numpy array, mineral density [kg/m^3].
-    phi : np.ndarray or float
+    rho_fl
+        N length numpy array, fluid density [kg/m^3].
+    phi
         N length numpy array, total porosity [ratio].
-    perm : np.ndarray or float
+    perm
         Float or N length numpy array, permeability [mD].
-    visco : np.ndarray or float
+    visco
         Float or N length numpy array, fluid viscosity [cP].
-    alpha : np.ndarray
+    alpha
         M or NxM length numpy array, inclusion aspect ratio [ratio].
-    v : np.ndarray
+    v
         M or NxM length numpy array, inclusion concentration [ratio].
-    tau : np.ndarray
+    tau
         M length numpy array, relaxation time [s].
-    frequency : float
+    frequency
         Single float, signal frequency [Hz].
-    angle : float
+    angle
         Single float, angle of symmetry plane [degree].
-    frac_inc_con : np.ndarray or float
+    frac_inc_con
         Single float or N length numpy array, fraction of connected inclusions [ratio].
-    frac_inc_ani : np.ndarray or float
+    frac_inc_ani
         Single float or N length numpy array, fraction of anisotropic inclusions [ratio].
-    pressure : [type], optional
+    pressure
         > 1 value list or numpy array in ascending order, effective pressure [Pa], by default None.
-    scenario : int, optional
+    scenario
         Pre-set scenarios for alpha, v and tau, by default None.
-    fcn : callable | str, optional
+    fcn
         Function with which to run the T-Matrix model or string with function name within t_matrix_models, by default None.
 
     Returns
     -------
-    tuple
-        vp, vsv, vsh, rho: (np.ndarray, np.ndarray, np.ndarray, np.ndarray).
+    vp
+        Vertical P-wave velocity [m/s].
+    vsv
+        Vertical polarity S-wave velocity [m/s].
+    vsh
+        Horizontal polarity S-wave velocity [m/s].
+    rho
+        Bulk density [kg/m^3].
     """
     # Check all input parameters and make sure that they are on expected format and shape
     (

--- a/src/rock_physics_open/t_matrix_models/t_matrix_C.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_C.py
@@ -31,50 +31,56 @@ def t_matrix_porosity_c_alpha_v(
     Array1D[np.float64],
     Array1D[np.float64],
 ]:
-    """This function can be called directly from top level, but the present recommendation is to go though the run_t_matrix
-    in order to check inputs. It is used directly from the optimisation functions for efficiency. This gives direct
-    access to the C++ compiled library for T-Matrix.
+    """Run the T-Matrix model via the compiled C++ library.
+
+    Can be called directly from top level, but the present recommendation is to go through `run_t_matrix`
+    in order to check inputs. It is used directly from the optimisation functions for efficiency.
 
     Parameters
     ----------
-    k_min : np.ndarray
-        N length array, mineral bulk modulus [Pa]
-    mu_min: np.ndarray
-        N length array, mineral shear modulus [Pa]
-    rho_min: np.ndarray
-        N length array, mineral density [kg/m^3]
-    k_fl:np.ndarray
-        N length array, fluid bulk modulus [Pa]
-    rho_fl: np.ndarray
-        N length array, fluid density [kg/m^3]
-    phi : np.ndarray
-        N length array, porosity
-    perm: np.ndarray
-        N length array, permeability [mD]
-    visco: np.ndarray
-        N length array, viscosity [cP]
-    alpha: np.ndarray or float
-        aspect ratios for inclusions
-    v: np. ndarray or float
-        fraction of porosity with given aspect ratio
-    tau: float
-        relaxation time
-    frequency: float
-        float single value, signal frequency [Hz]
-    angle: float
-        float single value, angle of symmetry plane (0 = HTI, 90 = VTI medium) [deg]
-    frac_inc_con: np.ndarray or float
-        float single value or array, fraction of inclusions that are connected
-    frac_inc_ani: np.ndarray or float
-        float single value or array, fraction of inclusions that are anisotropic
+    k_min
+        Mineral bulk modulus [Pa]
+    mu_min
+        Mineral shear modulus [Pa]
+    rho_min
+        Mineral density [kg/m^3]
+    k_fl
+        Fluid bulk modulus [Pa]
+    rho_fl
+        Fluid density [kg/m^3]
+    phi
+        Porosity
+    perm
+        Permeability [mD]
+    visco
+        Viscosity [cP]
+    alpha
+        Aspect ratios for inclusions
+    v
+        Fraction of porosity with given aspect ratio
+    tau
+        Relaxation time
+    frequency
+        Signal frequency [Hz]
+    angle
+        Angle of symmetry plane (0 = HTI, 90 = VTI medium) [deg]
+    frac_inc_con
+        Fraction of inclusions that are connected
+    frac_inc_ani
+        Fraction of inclusions that are anisotropic
 
     Returns
     -------
-    tuple
-        Tuple of np.ndarrays. Vp: Vertical P-wave velocity [m/s], Vsv: Vertical polarity S-wave velocity [m/s],
-        Vsh: Horizontal polarity S-wave velocity [m/s], Rhob [kg/m^3].
-    """
+    Vp
+        Vertical P-wave velocity [m/s].
+    Vsv
+        Vertical polarity S-wave velocity [m/s].
+    Vsh
+        Horizontal polarity S-wave velocity [m/s].
+    Rhob
+        Bulk density [kg/m^3].
 
+    """
     # ToDo: tau input is not used in the Calculo implementation of T-Matrix
     del tau
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
@@ -46,51 +46,71 @@ def run_t_matrix_with_opt_params_exp(
     Array1D[np.float64],
 ]:
     """Based on the input file with parameters for the optimally fitted model, the correct modelling version is run.
+
     Fluid substitution follows, in case it is selected. If not, the vp_sub and vs_sub will contain the same values as
     the input logs.
 
     Parameters
     ----------
-    fl_k_orig : np.ndarray
+    fl_k_orig
         Effective in situ fluid bulk modulus [Pa].
-    fl_rho_orig : np.ndarray
+    fl_rho_orig
         Effective in situ fluid density [kg/m^3].
-    fl_k_sub : np.ndarray
+    fl_k_sub
         Effective substituted fluid bulk modulus [Pa].
-    fl_rho_sub : np.ndarray
+    fl_rho_sub
         Effective substituted density [kg/m^3].
-    vp : np.ndarray
+    vp
         Compressional velocity [m/s].
-    vs : np.ndarray
+    vs
         Shear velocity [m/s].
-    rhob : np.ndarray
+    rhob
         Bulk density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    vsh : np.ndarray
+    vsh
         Shale volume [fraction].
-    angle : float
+    angle
         Angle of symmetry plane [degrees]
-    perm : float
+    perm
         Permeability [mD].
-    visco : float
+    visco
         Viscosity [cP].
-    tau : float
+    tau
         Relaxation time constant [s].
-    freq : float
+    freq
         Signal frequency [Hz].
-    f_name : str
+    f_name
         File name for parameter file for optimal parameters.
-    fluid_sub : bool
+    fluid_sub
         Boolean parameter to perform fluid substitution.
 
     Returns
     -------
-    tuple
-        Tuple of np.ndarrays: vp and vs for pressure substituted case, vp, vs and density for fluid substituted case, vp and vs for
-        optimal fitted model, vp and vs residuals (observed logs minus modelled values).
-    """
+    vp_sub
+        Fluid substituted p-wave velocity [m/s].
+    vs_sub
+        Fluid substituted s-wave velocity [m/s].
+    rho_sub
+        Fluid substituted density [kg/m^3].
+    ai_sub
+        Fluid substituted acoustic impedance [kg/m^3 x m/s].
+    vpvs_sub
+        Fluid substituted Vp/Vs ratio [ratio].
+    vp_mod
+        P-wave velocity from the optimal fitted model [m/s].
+    vs_mod
+        S-wave velocity from the optimal fitted model [m/s].
+    rho_mod
+        Density from the optimal fitted model [kg/m^3].
+    vp_res
+        P-wave residual (observed minus modelled) [m/s].
+    vs_res
+        S-wave residual (observed minus modelled) [m/s].
+    rho_res
+        Density residual (observed minus modelled) [kg/m^3].
 
+    """
     opt_type, opt_params, opt_dict = load_opt_params(f_name)
     y_data = np.stack([vp, vs], axis=1)
     y_shape = y_data.shape

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_petec.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_petec.py
@@ -47,57 +47,73 @@ def run_t_matrix_with_opt_params_petec(
     Array1D[np.float64],
 ]:
     """
-        Based on the input file with parameters for the optimally fitted model, the correct modelling version is run.
-        Fluid substitution follows, in case it is selected. If not, the vp_sub and vs_sub will contain the same values as
-        the input logs.
-    def run_t_matrix_with_opt_params_exp(fl_k_orig, fl_rho_orig, fl_k_sub, fl_rho_sub,
-                                     vp, vs, rhob,
-                                     phi, vsh,
-                                     angle, perm, visco, tau, freq,
-                                     f_name, fluid_sub=True):
-        Parameters
-        ----------
-        min_k : np.ndarray
-            Effective mineral bulk modulus [Pa].
-        min_mu : np.ndarray
-            Effective mineral shear modulus [Pa].
-        min_rho : np.ndarray
-            Effective mineral density [kg/m^3].
-        fl_k_orig : np.ndarray
-            Effective in situ fluid bulk modulus [Pa].
-        fl_rho_orig : np.ndarray
-            Effective in situ fluid density [kg/m^3].
-        fl_k_sub : np.ndarray
-            Effective substituted fluid bulk modulus [Pa].
-        fl_rho_sub : Effective substituted density [kg/m^3].
-        vp : np.ndarray
-            Compressional velocity [m/s].
-        vs : np.ndarray
-            Shear velocity [m/s].
-        rhob : np.ndarray
-            Bulk density [kg/m^3].
-        phi : np.ndarray
-            Porosity [fraction].
-        angle : float
-            Angle of symmetry plane [degrees]
-        perm : float
-            Permeability [mD].
-        visco : float
-            Viscosity [cP].
-        tau : float
-            Relaxation time constant [s].
-        freq : float
-            Signal frequency [Hz].
-        f_name : str
-            File name for parameter file for optimal parameters.
-        fluid_sub : bool
-            Boolean parameter to perform fluid substitution.
+    Based on the input file with parameters for the optimally fitted model, the correct modelling version is run.
 
-        Returns
-        -------
-        tuple
-            Tuple of np.ndarrays: vp and vs for pressure substituted case, vp, vs and density for fluid substituted case, vp and vs for
-            optimal fitted model, vp and vs residuals (observed logs minus modelled values).
+    Fluid substitution follows, in case it is selected. If not, the vp_sub and vs_sub will contain the same values as the input logs.
+
+    Parameters
+    ----------
+    min_k
+        Effective mineral bulk modulus [Pa].
+    min_mu
+        Effective mineral shear modulus [Pa].
+    min_rho
+        Effective mineral density [kg/m^3].
+    fl_k_orig
+        Effective in situ fluid bulk modulus [Pa].
+    fl_rho_orig
+        Effective in situ fluid density [kg/m^3].
+    fl_k_sub
+        Effective substituted fluid bulk modulus [Pa].
+    fl_rho_sub
+        Effective substituted density [kg/m^3].
+    vp
+        Compressional velocity [m/s].
+    vs
+        Shear velocity [m/s].
+    rhob
+        Bulk density [kg/m^3].
+    phi
+        Porosity [fraction].
+    angle
+        Angle of symmetry plane [degrees]
+    perm
+        Permeability [mD].
+    visco
+        Viscosity [cP].
+    tau
+        Relaxation time constant [s].
+    freq
+        Signal frequency [Hz].
+    f_name
+        File name for parameter file for optimal parameters.
+    fluid_sub
+        Boolean parameter to perform fluid substitution.
+
+    Returns
+    -------
+    vp_sub
+        Fluid substituted p-wave velocity [m/s].
+    vs_sub
+        Fluid substituted s-wave velocity [m/s].
+    rho_sub
+        Fluid substituted density [kg/m^3].
+    ai_sub
+        Fluid substituted acoustic impedance [kg/m^3 x m/s].
+    vpvs_sub
+        Fluid substituted Vp/Vs ratio [ratio].
+    vp_mod
+        P-wave velocity from the optimal fitted model [m/s].
+    vs_mod
+        S-wave velocity from the optimal fitted model [m/s].
+    rho_mod
+        Density from the optimal fitted model [kg/m^3].
+    vp_res
+        P-wave residual (observed minus modelled) [m/s].
+    vs_res
+        S-wave residual (observed minus modelled) [m/s].
+    rho_res
+        Density residual (observed minus modelled) [kg/m^3].
     """
     _, opt_params, _ = load_opt_params(f_name)
     y_data = np.stack([vp, vs], axis=1)

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
@@ -32,37 +32,54 @@ def run_t_matrix_forward_model_with_opt_params_exp(
     Array1D[np.float64],
     Array1D[np.float64],
 ]:
-    """Based on the input file with parameters for the optimally fitted model, a forward modelling is done
-    with inputs of mineral properties, fluid properties and porosity per sample. Other parameters (constants)
-    can also be varied from their setting when the optimal parameters were found.
+    """
+    Run forward modelling with the T-Matrix model using exponentially fitted parameters.
+
+    Based on the input file with parameters for the optimally fitted model, a forward modelling is done with inputs of mineral properties, fluid properties and porosity per sample
+    Other parameters (constants) can also be varied from their setting when the optimal parameters were found.
 
     Parameters
     ----------
-    fl_k : np.ndarray.
+    fl_k
         Effective in situ fluid bulk modulus [Pa].
-    fl_rho : np.ndarray
+    fl_rho
         Effective in situ fluid density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    vsh : np.ndarray
+    vsh
         Shale volume [fraction].
-    angle : float
+    angle
         Angle of symmetry plane
-    perm : float
+    perm
         Permeability [mD].
-    visco : float
+    visco
         Viscosity [cP].
-    tau : float
+    tau
         Relaxation time constant [s].
-    freq : float
+    freq
         Signal frequency [Hz].
-    f_name : str
+    f_name
         File name for parameter file for optimal parameters.
 
     Returns
     -------
-    tuple
-        Tuple of np.ndarrays: vp [m/s], vs [m/s], rho [kg/m^3], ai [kg/m^3 x m/s], vp/vs [fraction] for forward model.
+    vp
+        Modelled p-wave velocity [m/s].
+    vs
+        Modelled s-wave velocity [m/s].
+    rho
+        Modelled density [kg/m^3].
+    ai
+        Modelled acoustic impedance [kg/m^3 x m/s].
+    vpvs
+        Modelled Vp/Vs ratio [fraction].
+
+    Raises
+    ------
+    TypeError
+        If input file is incorrect.
+    ValueError
+        If forward model fails.
     """
     opt_type, opt_params, opt_dict = load_opt_params(f_name)
     _, scale_val, _ = opt_param_info()

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
@@ -33,41 +33,58 @@ def run_t_matrix_forward_model_with_opt_params_petec(
     Array1D[np.float64],
     Array1D[np.float64],
 ]:
-    """Based on the input file with parameters for the optimally fitted model, a forward modelling is done
-    with inputs of mineral properties, fluid properties and porosity per sample. Other parameters (constants)
-    can also be varied from their setting when the optimal parameters were found.
+    """
+    Run forward modelling with the T-Matrix model using optimally fitted parameters.
+
+    Based on the input file with parameters for the optimally fitted model, a forward modelling is done with inputs of mineral properties, fluid properties and porosity per sample.
+    Other parameters (constants) can also be varied from their setting when the optimal parameters were found.
 
     Parameters
     ----------
-    min_k : np.ndarray
+    min_k
         Effective mineral bulk modulus [Pa].
-    min_mu : np.ndarray
+    min_mu
         Effective mineral shear modulus [Pa].
-    min_rho : np.ndarray
+    min_rho
         Effective mineral density [kg/m^3].
-    fl_k : np.ndarray
+    fl_k
         Effective in situ fluid bulk modulus [Pa].
-    fl_rho : np.ndarray
+    fl_rho
         Effective in situ fluid density [kg/m^3].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    angle : float
+    angle
         Angle of symmetry plane [degrees]
-    perm : float
+    perm
         Permeability [mD].
-    visco : float
+    visco
         Viscosity [cP].
-    tau : float
+    tau
         Relaxation time constant [s].
-    freq : float
+    freq
         Signal frequency [Hz].
-    f_name : str
+    f_name
         File name for parameter file for optimal parameters.
 
     Returns
     -------
-    tuple
-        Tuple of np.ndarrays: vp [m/s], vs [m/s], rho [kg/m^3], ai [kg/m^3 x m/s], vp/vs [fraction] for forward model.
+    vp
+        Modelled p-wave velocity [m/s].
+    vs
+        Modelled s-wave velocity [m/s].
+    rho
+        Modelled density [kg/m^3].
+    ai
+        Modelled acoustic impedance [kg/m^3 x m/s].
+    vpvs
+        Modelled Vp/Vs ratio [fraction].
+
+    Raises
+    ------
+    TypeError
+        If input file is incorrect.
+    ValueError
+        If forward model fails.
     """
     opt_type, opt_params, _ = load_opt_params(f_name)
     phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = cast(

--- a/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_exp.py
@@ -45,47 +45,59 @@ def t_matrix_optimisation_exp(
     Array1D[np.float64],
 ]:
     """T-Matrix optimisation adapted to an exploration setting, where detailed well information is generally not known.
+
     Inclusion parameters are optimised for the whole well.
 
     Parameters
     ----------
-    por : np.ndarray
-        Inclusion porosity [ratio].
-    vsh : np.ndarray
-        Shale volume [ratio].
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         Fluid density [kg/m^3].
-    vp : np.ndarray
+    por
+        Inclusion porosity [ratio].
+    vsh
+        Shale volume [ratio].
+    vp
         Compressional velocity log [m/s].
-    vs : np.ndarray
+    vs
         Shear velocity log [m/s].
-    rhob : np.ndarray
+    rhob
         Bulk density log [kg/m^3].
-    angle : float
+    angle
         Angle of symmetry plane [degrees]
-    k_r : float
+    k_r
         Permeability [mD].
-    eta_f : float
+    eta_f
         Fluid viscosity [cP].
-    tau : float
+    tau
         Relaxation time constant [s].
-    freq : float
+    freq
         Signal frequency [Hz].
-    file_out_str : str
+    file_out_str
         Output file name (string) to store optimal parameters (pickle format).
-    display_results : bool
+    display_results
         Display optimal parameters in a window after run.
-    well_name : str
+    well_name
         Name of well to be displayed in info box title.
-    opt_kwargs : Any
+    **opt_kwargs
         Additional keywords to be passed to optimisation function
 
     Returns
     -------
-    tuple
-        vp_mod, vs_mod - modelled logs, vp_res, vs_res - residual logs.
+    vp_mod
+        Modelled p-wave velocity log.
+    vs_mod
+        Modelled s-wave velocity log.
+    vp_res
+        P-wave velocity residual log.
+    vs_res
+        S-wave velocity residual log.
+
+    Raises
+    ------
+    ValueError
+        If optimisation fails.
     """
     # 1. Preparation that is independent of search for minimum possible aspect ratio for second inclusion set
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_min.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_min.py
@@ -46,53 +46,73 @@ def t_matrix_optimisation_petec(
     Array1D[np.float64],
     Array1D[np.float64],
 ]:
-    """T-Matrix optimisation adapted to a case with detailed information available, such as in a development or production
-    setting. Mineral and fluid composition should be known on a sample basis. Inclusion parameters are regarded as
+    """T-Matrix optimisation adapted to a case with detailed information available, such as in a development or production setting.
+
+    Mineral and fluid composition should be known on a sample basis. Inclusion parameters are regarded as
     unknown and they are optimised for.
 
     Parameters
     ----------
-    k_min :
+    k_min
         Effective mineral bulk modulus [Pa].
-    mu_min :
+    mu_min
         Effective mineral shear modulus [Pa].
-    rho_min :
+    rho_min
         Effective mineral bulk density [kg/m^3].
-    k_fl :
+    k_fl
         Effective fluid bulk modulus [Pa].
-    rho_fl :
+    rho_fl
         Effective fluid density [kg/m^3].
-    por :
+    por
         Inclusion porosity [ratio].
-    vp :
+    vp
         Compressional velocity log [m/s].
-    vs :
+    vs
         Shear velocity log [m/s].
-    rhob :
+    rhob
         Bulk density log [kg/m^3].
-    angle : float
+    angle
         Angle of symmetry plane [degrees]
-    k_r :
+    k_r
         Permeability [mD].
-    eta_f :
+    eta_f
         Fluid viscosity [cP].
-    tau :
+    tau
         Relaxation time constant [s].
-    freq :
+    freq
         Signal frequency [Hz].
-    file_out_str :
+    file_out_str
         Output file name (string) to store optimal parameters (pickle format).
-    display_results :
+    display_results
         Display optimal parameters in a window after run.
-    well_name:
+    well_name
         Name of well to be displayed in info box title.
-    opt_kwargs:
-        Additional keywords to be passed to optimisation function
+    **opt_kwargs
+        Additional keywords to be passed to optimisation function.
 
     Returns
     -------
-    tuple
-        vp_mod, vs_mod, rho_mod, ai_mod, vpvs_mod - modelled logs, vp_res, vs_res, rho_res - residual logs.
+    vp_mod
+        Modelled p-wave velocity log.
+    vs_mod
+        Modelled s-wave velocity log.
+    rho_mod
+        Modelled density log.
+    ai_mod
+        Modelled acoustic impedance log.
+    vpvs_mod
+        Modelled Vp/Vs ratio log.
+    vp_res
+        P-wave velocity residual log.
+    vs_res
+        S-wave velocity residual log.
+    rho_res
+        Density residual log.
+
+    Raises
+    ------
+    ValueError
+        If optimisation fails.
     """
     # 1. Preparation that is independent of search for minimum possible aspect ratio for second inclusion set
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/array_functions.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/array_functions.py
@@ -1,24 +1,22 @@
-from typing import TypeVar
-
 import numpy as np
 
-from rock_physics_open.equinor_utilities.various_utilities.types import Array3D
+from rock_physics_open.equinor_utilities.various_utilities.types import (
+    Array3D,
+    ComplexOrFloat,
+)
 
-_T = TypeVar("_T", np.float64, np.complex128)
 
-
-def array_inverse(a: Array3D[_T]) -> Array3D[_T]:
+def array_inverse(a: Array3D[ComplexOrFloat]) -> Array3D[ComplexOrFloat]:
     """Inverse of higher order array (3 dim) using linalg inv routine.
 
     Parameters
     ----------
-    a : np.ndarray
+    a
         An nxmxm numpy array.
 
     Returns
     -------
-    np.ndarray
-        An nxmxm array where [i, :, :] contains the inverse of A[i, :, :].
+    An nxmxm array where [i, :, :] contains the inverse of A[i, :, :].
 
     Raises
     ------
@@ -33,24 +31,23 @@ def array_inverse(a: Array3D[_T]) -> Array3D[_T]:
 
 
 def array_matrix_mult(
-    *args: Array3D[_T],
-) -> Array3D[_T]:
+    *args: Array3D[ComplexOrFloat],
+) -> Array3D[ComplexOrFloat]:
     """3-dim arrays are matrix multiplied args[j][i, :, :] @ args[j+1][i, :, :].
-    Input args should all be numpy arrays of shape nxmxm.
+
+    Parameters
+    ----------
+    *args
+        Numpy arrays of shape nxmxm.
 
     Returns
     -------
-    np.ndarray
-        An nxmxm array with n args[i] @ args[i+1] @ ....
+    An nxmxm array with n args[i] @ args[i+1] @ ....
 
     Raises
     ------
     ValueError
-        If input is not a list or tuple.
-    ValueError
-        If mismatch in input shape/dimension.
-    ValueError
-        If mismatch in input shape/dimension.
+        If input is not a list or tuple or if there is a mismatch in input shape/dimension.
     """
     if len(args) == 0:
         raise ValueError(f"{__name__}: no input arguments provided")

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_c_eff.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_c_eff.py
@@ -23,32 +23,36 @@ def calc_c_eff_vec(
     frac_aniso: float,
 ) -> Array3D[np.float64]:
     """
-    Equation  4 (page 222) Jakobsen et al. 2003 (The acoustic signature of fluid flow in complex
-    porous media).
+    Equation  4 (page 222) Jakobsen et al. 2003 (The acoustic signature of fluid flow in complex porous media).
+
     Returns the effective stiffness tensor C* (nx6x6 matrix) calculated from the t-matrices t(r) (Eq. 1).
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         Stiffness tensor of the host of the inclusion (nx6x6 matrix).
-    c1 : np.ndarray
+    c1
         Sum of the concentration and t-matrices (nx6x6 matrix).
-    gd : np.ndarray
+    gd
         Correlation function (nx6x6 matrix).
-    t : np.ndarray
+    t
         t-matrices of the different inclusions (nx6x6xr matrix) (anisotropic).
-    t_bar: np.ndarray
+    t_bar
         t-matrices of the different inclusions (nx6x6xr matrix) (isotropic).
-    v : np.ndarray
+    v
         Concentration of the inclusions (nxr vector).
-    frac_aniso: np.ndarray
+    frac_aniso
         Fraction of anisotropic.
 
     Returns
     -------
-    tuple
-        c_eff: np.ndarray.
-        c_eff: effective stiffness tensor C.
+    c_eff: np.ndarray.
+    c_eff: effective stiffness tensor C.
+
+    Raises
+    ------
+    ValueError
+        If input dimensions or shapes are inconsistent.
     """
     if not (
         c0.ndim == 3
@@ -121,50 +125,49 @@ def calc_c_eff_visco_vec(
 
     Parameters
     ----------
-    vs : np.ndarray
+    vs
         The velocity used to calculate the wave number.
-    k_r : np.ndarray
+    k_r
         Klinkenberg permeability.
-    eta_f : np.ndarray
+    eta_f
         Viscosity (P).
-    v : np.ndarray
+    v
         Concentration of the inclusions which are connected with respect to fluid flow.
-    gamma : np.ndarray
+    gamma
         Gamma factor for each inclusion (1x(number of connected inclusions) vector).
-    tau : float or np.ndarray
+    tau
         Relaxation time constant.
-    kd_uuvv : np.ndarray
+    kd_uuvv
         Kd_uuvv for each connected inclusion (1x(number of connected inclusions) vector.
-    kappa : np.ndarray
+    kappa
         Bulk modulus of host material.
-    kappa_f : np.ndarray
+    kappa_f
         Bulk modulus of the fluid.
-    c0 : np.ndarray
+    c0
         The stiffness tensor of host material (6x6 matrix).
-    s0 : np.ndarray
+    s0
         Inverse of C0.
-    c1 : np.ndarray
+    c1
         First order correction matrix(6x6 matrix). If there are isolated inclusions, C1 is sum of concentration and
         t-matrices of the isolated part of the porosity.
-    td : np.ndarray
+    td
         t-matrix tensors.
-    td_bar : np.ndarray
+    td_bar
         t-matrices of the connected inclusions(6x6x(numbers of inclusions) matrix).
-    x : np.ndarray
+    x
         X-tensor.
-    x_bar : np.ndarray
+    x_bar
         X-tensor of the connected inclusions (6x6x(numbers of inclusions) matrix).
-    gd : np.ndarray
+    gd
         Correlation function (6x6 matrix).
-    frequency : float
+    frequency
         Frequency under consideration.
-    frac_ani : np.ndarray
+    frac_ani
         Fraction of anisotropic inclusions.
 
     Returns
     -------
-    np.ndarray
-        Effective stiffness tensor.
+    Effective stiffness tensor.
     """
     dr = k_r / eta_f
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_isolated.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_isolated.py
@@ -23,33 +23,37 @@ def calc_isolated_part_vec(
     frac_ani: float,
 ) -> Array3D[np.float64]:
     """
-    Returns the first order correction tensor: sum of the concentrations and
-    t-matrices of the isolated porosity (6x6 matrix).
+    Returns the first order correction tensor: sum of the concentrations and t-matrices of the isolated porosity (6x6 matrix).
+
     case_iso = 0 : 100% isotropic,
     case_iso = 1 : mixed isotropic and anisotropic porosity,
     case_iso = 2 : 100% anisotropic porosity.
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         Stiffness tensor of the host material (6x6xn).
-    s_0 :  np.ndarray
+    s_0
         Inverse of stiffness tensor.
-    kappa_f : np.ndarray
+    kappa_f
         Bulk modulus of the fluid (n length vector).
-    alpha : np.ndarray
+    alpha
         Aspect ratios of all the inclusions (1xnumber of inclusions) vector).
-    v : np.ndarray
+    v
         Concentration of all the inclusions (1xnumber of inclusions) vector).
-    case_iso : int
+    case_iso
         Control parameter.
-    frac_ani : float
+    frac_ani
         Fraction of anisotropic inclusions.
 
     Returns
     -------
-    np.ndarray
-        c1: correction tensor.
+    c1: correction tensor.
+
+    Raises
+    ------
+    ValueError
+        If input dimensions or shapes are inconsistent.
 
     Notes
     -----
@@ -57,7 +61,6 @@ def calc_isolated_part_vec(
     Remy's code, but this function had assumption that half of the inclusions could have different aspect ratio
     13.11.2020 HFLE: In case of zero porosity, this routine returns a zero tensor, whereas the correct should have
     been to return the host material tensor - corrected.
-
     """
     if not (c0.ndim == 3 and s_0.ndim == 3):
         raise ValueError(f"{__name__}: mismatch in inputs variables dimension/shape")

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd.py
@@ -17,23 +17,22 @@ def calc_kd_vec(
     alpha: Array2D[np.float64],
 ) -> Array4D[np.float64]:
     """
-    kd is a (nx6x6x(number of alphas)) matrix.
+    Kd is a (nx6x6x(number of alphas)) matrix.
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         Stiffness tensor of the host material (nx6x6 matrix).
-    i4 : np.ndarray
+    i4
         Array of 6x6 identity matrices.
-    s_0:  np.ndarray
+    s_0
         Inverse of stiffness tensor.
-    alpha : np.ndarray
+    alpha
         Vector of aspect ratios (1x (number of aspect ratios) vector) or nx(number of (number of alphas)).
 
     Returns
     -------
-    np.ndarray
-        kd: stiffness tensor.
+    Stiffness tensor.
     """
     log_length = c0.shape[0]
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd_eff.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd_eff.py
@@ -27,6 +27,7 @@ def calc_kd_eff_vec(
     frac_ani: float,
 ) -> tuple[Array4D[np.float64] | None, Array4D[np.float64] | None]:
     """Returns the effective dry K-tensor (6x6x(numbers of inclusions) matrix.
+
     If there is no connected or no isolated pores, the function returns a NaN for
     the case which is not considered. E.g. if only isolated pores, the kd_eff_connected = NaN.
 
@@ -35,41 +36,43 @@ def calc_kd_eff_vec(
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         Stiffness tensor of the host material (nx6x6 matrix).
-    s_0 : np.ndarray
+    s_0
         Inverse of the stiffness tensor.
-    k_fl : np.ndarray
+    k_fl
         Bulk modulus of the fluid (n length vector).
-    alpha_con : np.ndarray
+    alpha_con
         Aspect ratio of connected inclusions.
-    alpha_iso : np.ndarray
+    alpha_iso
         Aspect ratio of isolated inclusions.
-    v_con : np.ndarray
+    v_con
         Concentration of connected pores.
-    v_iso : np.ndarray
+    v_iso
         Concentration of isolated pores.
-    gd : np.ndarray
+    gd
         Correlation function (nx6x6 matrix).
-    ctrl : int
+    ctrl
         0 :only isolated pores, 1 :both isolated and connected pores, 2 :only connected pores.
-    frac_ani : float
+    frac_ani
         Fraction of anisotropic inclusions.
 
     Returns
     -------
-    tuple
-         kd_eff_isolated, kd_eff_connected: (np.ndarray, np.ndarray).
+    kd_eff_isolated
+        Effective dry K-tensor for isolated inclusions.
+    kd_eff_connected
+        Effective dry K-tensor for connected inclusions.
 
     Notes
     -----
     Equations used can be found in:
     Agersborg (2007), phd thesis:
-    https://bora.uib.no/handle/1956/2422
+    https
 
     09.03.2012
     Remy Agersborg
-    email: remy@agersborg.com
+    email
 
     Translated to Python and vectorised by Harald Flesche, hfle@equinor.com 2020.
     """

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd_uuv.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_kd_uuv.py
@@ -8,13 +8,12 @@ def calc_kd_uuvv_vec(kd: Array4D[np.float64]) -> Array2D[np.float64]:
 
     Parameters
     ----------
-    kd : np.ndarray
+    kd
         The dry K-tensor (n, 6,6,(numbers of inclusions)) matrix.
 
     Returns
     -------
-    np.ndarray
-        Summed elements.
+    Summed elements.
 
     """
     return np.sum(kd[:, :3, :3, :], axis=(1, 2))

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
@@ -38,48 +38,57 @@ def calc_pressure_vec(
 
     Parameters
     ----------
-    alpha_con : np.ndarray
+    alpha_con
         Aspect ratio for connected inclusions (r length vector).
-    alpha_iso : np.ndarray
+    alpha_iso
         Aspect ratio for connected inclusions (s length vector).
-    v_con : np.ndarray
+    v_con
         Volume of connected inclusions (r length vector).
-    v_iso : np.ndarray
+    v_iso
         Volume of connected inclusions (s length vector).
-    c0 : np.ndarray
+    c0
         Stiffness tensor of host material (nx6x6 array).
-    s_0 : np.ndarray
+    s_0
         Inverse of stiffness tensor (nx6x6 array).
-    gd : np.ndarray
+    gd
         The correlation function (green's tensor nx6x6 matrix).
-    d_p : float
+    d_p
         Change in effective pressure.
-    tau : np.ndarray
+    tau
         Relaxation time constant ((numbers of connected pores) vector).
-    gamma : np.ndarray
+    gamma
         Gamma factor ((numbers of connected pores) vector).
-    k_fl : np.ndarray
+    k_fl
         Fluid bulk modulus (n length vector).
-    ctrl : int
+    ctrl
         Control parameter.
-    frac_ani : float
+    frac_ani
         Fraction of anisotropic inclusions.
 
     Returns
     -------
-    tuple
-        alpha_n_connected, v_n_connected, alpha_n_isolated, v_n_isolated, tau_n_out, gamma_n_out -
-        modified alphas, volumes, relaxation times and gamma factors.
+    alpha_n_connected
+        Modified aspect ratios for connected inclusions.
+    v_n_connected
+        Modified volumes for connected inclusions.
+    alpha_n_isolated
+        Modified aspect ratios for isolated inclusions.
+    v_n_isolated
+        Modified volumes for isolated inclusions.
+    tau_n_out
+        Modified relaxation times.
+    gamma_n_out
+        Modified gamma factors.
 
     Notes
     -----
     Equations used can be found in:
     Agersborg (2007), phd thesis:
-    https://bora.uib.no/handle/1956/2422
+    https
 
     09.03.2012
     Remy Agersborg
-    email: remy@agersborg.com
+    email
 
     Translated to Python and vectorised by Harald Flesche, hfle@equinor.com 2020
     """

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_t.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_t.py
@@ -19,32 +19,35 @@ def calc_t_vec(
     k_fluid: Array1D[np.float64],
 ) -> Array4D[np.complex128]:
     """
-    Returns the t-matrices (6x6x(numbers of connected pores)) of the
-    connected pores.
+    Returns the t-matrices (6x6x(numbers of connected pores)) of the connected pores.
 
     Parameters
     ----------
-    td : np.ndarray
+    td
         Dry t-matrix tensors, (nx6x6x(numbers of empty cavities) matrix).
-    theta : np.ndarray
+    theta
         Theta-tensor (nx6x6 matrix).
-    x : np.ndarray
+    x
         X-tensor (nx6x6x(numbers of empty cavities) matrix).
-    z : np.ndarray
+    z
         Z-tensor (nx6x6x(numbers of empty cavities) matrix).
-    omega : np.ndarray
+    omega
         Frequency (2*pi*f).
-    gamma : np.ndarray
+    gamma
         Gamma factor of all the inclusions (nx(numbers of empty cavities) vector).
-    tau : np.ndarray
+    tau
         Relaxation time constant (1x(numbers of empty cavities) vector).
-    k_fluid : np.ndarray
+    k_fluid
         Bulk modulus of the fluid.
 
     Returns
     -------
-    np.ndarray
-        t-matrices.
+    t-matrices.
+
+    Raises
+    ------
+    ValueError
+        If input dimensions or shapes are inconsistent.
     """
     if not (
         td.ndim == 4

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_td.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_td.py
@@ -21,22 +21,21 @@ def calc_td_vec(
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         Stiffness tensor of the host material (nx6x6 matrix).
-    i4 : np.ndarray
+    i4
         An n x Identity matrix.
-    s_0 : np.ndarray
+    s_0
         Inverse of stiffness tensor.
-    kd : np.ndarray
+    kd
         Dry K tensor of all the empty cavities (nx6x6x(numbers of empty cavities) matrix) see Agersborg et al.
         2009 for explanation.
-    alpha : np.ndarray
+    alpha
         Aspect ratios of all the empty cavities (1x(numbers of empty cavities) vector).
 
     Returns
     -------
-    np.ndarray
-        Dry t-matrix tensors.
+    Dry t-matrix tensors.
     """
     log_len = c0.shape[0]
     if alpha.ndim == 1 and alpha.shape[0] != c0.shape[0]:

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_theta.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_theta.py
@@ -18,36 +18,37 @@ def calc_theta_vec(
     kappa: Array1D[np.float64],
     kappa_f: Array1D[np.float64],
 ) -> Array3D[np.complex128]:
-    """Returns the theta tensor (6x6 matrix) for more explanation see e.g.
-    Agersborg et al. 2009 or "The effects of drained and undrained loading in
+    """Returns the theta tensor (6x6 matrix).
+
+    For more explanation see e.g. Agersborg et al. 2009 or
+    "The effects of drained and undrained loading in
     visco-elastic waves in rock-like composites" M. Jakobsen and T.A. Johansen.
     (2005). Int. J. Solids and Structures (42). p. 1597-1611.
 
     Parameters
     ----------
-    v  : np.ndarray
+    v
         Concentration of all the empty cavities (1x(numbers of empty cavities) vector).
-    omega : np.ndarray
+    omega
         Frequency (2*pi*f).
-    gamma : np.ndarray
+    gamma
         Gamma factor of all the inclusions (1x(numbers of empty cavities) vector).
-    tau : np.ndarray
+    tau
         Relaxation time constant (1x(numbers of empty cavities) vector).
-    kd_uuvv : np.ndarray
+    kd_uuvv
         Tensor sum of the dry K tensor for all the cavities (1x(numbers of empty cavities) vector).
-    dr : np.ndarray
+    dr
         Permeability/viscosity.
-    k : np.ndarray
+    k
         Wave number vector.
-    kappa : np.ndarray
+    kappa
         Bulk modulus of the host material.
-    kappa_f : np.ndarray
+    kappa_f
         Bulk modulus of the fluid.
 
     Returns
     -------
-    np.ndarray
-        Theta tensor.
+    Theta tensor.
     """
     sigma_a = np.sum((v / (1 + 1j * omega * gamma * tau)), axis=1)
     sigma_b = np.sum((v / (1 + 1j * omega * gamma * tau)) * kd_uuvv, axis=1)

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_x.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_x.py
@@ -10,22 +10,23 @@ def calc_x_vec(
     s_0: Array3D[np.float64],
     td: Array4D[np.float64],
 ) -> Array4D[np.float64]:
-    """Returns the x-tensor (6x6x(numbers of empty cavities) matrix) for more explanation see e.g.
-    Agersborg et al. 2009 or "The effects of drained and undrained loading in
+    """Returns the x-tensor (6x6x(numbers of empty cavities) matrix).
+
+    For more explanation see e.g. Agersborg et al. 2009
+    or "The effects of drained and undrained loading in
     visco-elastic waves in rock-like composites" M. Jakobsen and T.A. Johansen.
-    (2005). Int. J. Solids and Structures (42). p. 1597-1611
+    (2005). Int. J. Solids and Structures (42). p. 1597-1611.
 
     Parameters
     ----------
-    s_0: np.ndarray
+    s_0
         Inverse of stiffness tensor of the host material (nx6x6 matrix).
-    td :  np.ndarray
+    td
         Dry t-matrix tensors (nx6x6x(numbers of empty cavities) matrix).
 
     Returns
     -------
-    np.ndarray
-        x-tensor.
+    x-tensor.
     """
     i2_i2, log_length, alpha_length = check_and_tile(s_0, td)
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_z.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_z.py
@@ -20,32 +20,35 @@ def calc_z_vec(
     v: Array2D[np.float64],
     tau: Array1D[np.float64],
 ) -> tuple[Array4D[np.complex128], Array4D[np.complex128]]:
-    """Returns the z tensor (6x6x(numbers of empty cavities) matrix) for more explanation see e.g.
-    Agersborg et al. 2009 or "The effects of drained and undrained loading in
+    """Returns the z tensor (6x6x(numbers of empty cavities) matrix).
+
+    For more explanation see e.g. Agersborg et al. 2009 or "The effects of drained and undrained loading in
     visco-elastic waves in rock-like composites" M. Jakobsen and T.A. Johansen.
     (2005). Int. J. Solids and Structures (42). p. 1597-1611.
 
     Parameters
     ----------
-    s0  : np.ndarray
+    s0
         Stiffness tensor of the host material (6x6 matrix).
-    td  : np.ndarray
+    td
         Dry t-matrix tensors, (6x6x(numbers of empty cavities) matrix).
-    td_bar  : np.ndarray
+    td_bar
         Dry t-matrix tensors, (6x6x(numbers of empty cavities) matrix).
-    omega : np.ndarray
+    omega
         Frequency (2*pi*f).
-    gamma : np.ndarray
+    gamma
         Gamma factor of all the inclusions (1x(numbers of empty cavities) vector).
-    v  :  np.ndarray
+    v
         Concentration of all the empty cavities (1x(numbers of empty cavities) vector).
-    tau  :  np.ndarray
+    tau
         Relaxation time constant (1x(numbers of empty cavities) vector).
 
     Returns
     -------
-    tuple
-        z, z_bar : (np.ndarray, np.ndarray).
+    z
+        Z tensor.
+    z_bar
+        Conjugate Z tensor.
     """
     i2_i2, log_length, alpha_length = check_and_tile(s0, td)
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/check_and_tile.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/check_and_tile.py
@@ -11,16 +11,24 @@ def check_and_tile(
 
     Parameters
     ----------
-    s : np.ndarray
+    s
         s parameter.
-    t : np.ndarray
+    t
         t parameter.
 
     Returns
     -------
-    tuple
-        i2_i2, log_length, alpha_length : (np.ndarray, int, int).
-        i2_i2: array with upper left matrices set to 1, log_length: array dimension, alpha_length: number of inclusions.
+    i2_i2
+        Array with upper left matrices set to 1.
+    log_length
+        Array dimension.
+    alpha_length
+        Number of inclusions.
+
+    Raises
+    ------
+    ValueError
+        If input dimensions or shapes are inconsistent.
     """
     if not (
         s.ndim == 3

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/g_tensor.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/g_tensor.py
@@ -14,17 +14,16 @@ def g_tensor_vec(
 
     Parameters
     ----------
-    c0 : np.ndarray
+    c0
         n stiffness tensors of the host material (nx6x6 array).
-    s_0 : np.ndarray
+    s_0
         Inverse of stiffness tensor.
-    alpha : float | np.ndarray
+    alpha
         Aspect ratio for single inclusion.
 
     Returns
     -------
-    np.ndarray
-        g-tensor.
+    g-tensor.
 
     Raises
     ------

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/iso_av.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/iso_av.py
@@ -1,19 +1,10 @@
-from typing import TypeVar
-
 import numpy as np
 
-from rock_physics_open.equinor_utilities.various_utilities.types import Array3D, Array4D
-
-_T = TypeVar(
-    "_T",
-    Array3D[np.float64],
-    Array4D[np.float64],
-)
+from rock_physics_open.equinor_utilities.various_utilities.types import Array3Or4D
 
 
-def iso_av_vec(t: _T) -> _T:
+def iso_av_vec(t: Array3Or4D) -> Array3Or4D:
     """Returns a (nx6x6) matrix t_bar averaged over all the orientations (isotropy).
-
 
     t_bar = np.array([
 
@@ -34,14 +25,13 @@ def iso_av_vec(t: _T) -> _T:
 
     Parameters
     ----------
-    t : np.ndarray
+    t
         An nx6x6 matrix which has a HTI symmetry.
 
 
     Returns
     -------
-    np.ndarray
-        Averaged value.
+    Averaged value.
     """
     t_bar = np.zeros_like(t)
 

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/pressure_input.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/pressure_input.py
@@ -15,18 +15,21 @@ def pressure_input_utility(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         Effective mineral bulk modulus [Pa].
-    mu_min : np.ndarray
+    mu_min
         Effective mineral shear modulus [Pa].
-    log_length : int
+    log_length
         Number of samples in logs.
 
     Returns
     -------
-    tuple
-        c0 (background stiffness), s0 (inverse of background stiffness), gd (G tensor for inclusions with aspect
-        ratio 1.0).
+    c0
+        Background stiffness.
+    s0
+        Inverse of background stiffness.
+    gd
+        G tensor for inclusions with aspect ratio 1.0.
     """
     # Calculate elastic parameters
     c11 = k_min + 4 / 3 * mu_min

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/t_matrix_vec.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/t_matrix_vec.py
@@ -56,8 +56,10 @@ def t_matrix_porosity_vectorised(
     Array2D[np.float64],
     Array2D[np.float64],
 ]:
-    """Vectorised version of T-Matrix, pure Python version - mainly intended for cases where it is wished to follow
-    the entire process through and study intermediate results. The C++ implementation is significantly faster.
+    """Vectorised version of T-Matrix, pure Python version.
+
+    Mainly intended for cases where it is wished to follow the entire process through and study intermediate results.
+    The C++ implementation is significantly faster.
 
     Description of inputs:
     Mineral properties (effective properties, assumed mixed).
@@ -65,44 +67,49 @@ def t_matrix_porosity_vectorised(
 
     Parameters
     ----------
-    k_min : np.ndarray
+    k_min
         N length array, bulk modulus of matrix/mineral [Pa].
-    mu_min : np.ndarray
+    mu_min
         N length array, shear modulus of matrix/mineral [Pa].
-    rho_min : np.ndarray
+    rho_min
         N length array, density of matrix/mineral [kg/m^3].
-    k_fl : np.ndarray
+    k_fl
         N length array, bulk modulus of fluid [Pa].
-    rho_fl : np.ndarray
+    rho_fl
         N length array, density of fluid [kg/m^3].
-    phi : np.ndarray
+    phi
         N length array, porosity [fraction].
-    perm : np.ndarray
+    perm
         Single float or N length array, permeability [mD].
-    visco : np.ndarray
+    visco
         Single float or N length array, fluid viscosity [cP].
-    alpha : np.ndarray
+    alpha
         M length vector, aspect ratio for inclusion sets [ratio].
-    v : np.ndarray
+    v
         M length vector, fraction of porosity belonging to each inclusion set [fraction].
-    tau : np.ndarray
+    tau
         M length vector, relaxation time constant [s].
-    frequency : float
+    frequency
         Single float, measurement frequency (seismic, sonic, ultrasonic range) [Hz].
-    angle : float
+    angle
         Single float, angle of symmetry plane (0 = HTI, 90 = VTI medium).
-    frac_inc_con : float or np.ndarray
+    frac_inc_con
         Single float or N length array, fraction of inclusions that are connected.
-    frac_inc_ani : float or np.ndarray
+    frac_inc_ani
         Single float or N length array, fraction of inclusions that are anisotropic.
-    pressure : np.ndarray, optional
+    pressure
         L length array (normally 2), by default None.
 
     Returns
     -------
-    tuple
-        Of type (np.ndarray, np.ndarray, np.ndarray, np.ndarray). Vertical P-wave velocity [m/s], Vsv: Vertical polarity S-wave velocity [m/s],
-        Vsh: Horizontal polarity S-wave velocity [m/s], rho_b: bulk density [kg/m^3].
+    vp
+        Vertical P-wave velocity [m/s].
+    vsv
+        Vertical polarity S-wave velocity [m/s].
+    vsh
+        Horizontal polarity S-wave velocity [m/s].
+    rho_b
+        Bulk density [kg/m^3].
     """
     log_length = len(phi)
     # Check that the inputs that should have the same length actually do

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/velocity_vti_angles.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/velocity_vti_angles.py
@@ -12,18 +12,26 @@ def velocity_vti_angles_vec(
 
     Parameters
     ----------
-    c_eff : np.ndarray
+    c_eff
         Effective stiffness tensor (nx6x6 matrix).
-    rho_eff : np.ndarray
+    rho_eff
         Effective density.
-    angle : float
+    angle
         The angle between the wave vector and the axis of symmetry.
 
     Returns
     -------
-    tuple[np.ndarray, np.ndarray, np.ndarray]
-        vp_out, vsv_out, vsh_out
-        vp_out, vsv_out, vsh_out : p-velocity, vertical polarisation s-velocity, horizontal polarisation s-velocity.
+    vp_out
+        P-wave velocity.
+    vsv_out
+        Vertical polarisation S-wave velocity.
+    vsh_out
+        Horizontal polarisation S-wave velocity.
+
+    Raises
+    ------
+    ValueError
+        If velocity_vti_angles are inconsistent.
     """
     if not (
         c_eff.ndim == 3

--- a/src/rock_physics_open/ternary_plots/shale_prop_ternary.py
+++ b/src/rock_physics_open/ternary_plots/shale_prop_ternary.py
@@ -24,29 +24,28 @@ def shale_prop_ternary(
 
     Parameters
     ----------
-    quartz : np.ndarray
+    quartz
         Quartz volume fraction [fraction].
-    carb : np.ndarray
+    carb
         Carbonate volume fraction [fraction].
-    clay : np.ndarray
+    clay
         Clay volume fraction [fraction].
-    kero : np.ndarray
+    kero
         Kerogen volume fraction [fraction].
-    phit : np.ndarray
+    phit
         Porosity [fraction].
-    col_code : np.ndarray
+    col_code
         Property used for colour coding [unknown].
-    name_col_code : str
+    name_col_code
         Plot annotation of log used for colour coding.
-    well_name : str
+    well_name
         Plot heading with well name.
-    draw_figures : bool
+    draw_figures
         Decide if figures are drawn or not, default is True.
 
     Returns
     -------
-    np.ndarray
-        hardness [float].
+    hardness [float].
     """
     KEROMAX = 0.25
 

--- a/src/rock_physics_open/ternary_plots/ternary_patches.py
+++ b/src/rock_physics_open/ternary_plots/ternary_patches.py
@@ -27,23 +27,22 @@ def ternary_patches(
 
     Parameters
     ----------
-    quartz : np.ndarray
+    quartz
         Quartz volume fraction [fraction].
-    carb : np.ndarray
+    carb
         Carbonate volume fraction [fraction].
-    clay : np.ndarray
+    clay
         Clay volume fraction [fraction].
-    kero : np.ndarray
+    kero
         Kerogen volume fraction [fraction].
-    well_name : str
+    well_name
         Plot heading with well name.
-    draw_figures : bool
+    draw_figures
         Decide if figures are drawn or not, default is True.
 
     Returns
     -------
-    np.ndarray
-        Lithology class [int].
+    Lithology class [int].
     """
     _, ax = set_ternary_figure(
         delta_x=0,

--- a/src/rock_physics_open/ternary_plots/ternary_plot_utilities.py
+++ b/src/rock_physics_open/ternary_plots/ternary_plot_utilities.py
@@ -24,10 +24,7 @@ def set_ternary_figure(
     title: str,
     well_name: str,
 ) -> tuple[Figure, Axes]:
-    """Find screen size, and make a suitable figure size and position, shift window with
-    number of steps given by deltaX and deltaY.
-    """
-
+    """Find screen size, and make a suitable figure size and position, shift window with number of steps given by deltaX and deltaY."""
     if platform.system() == "Windows":
         dc = ctypes.windll.user32.GetDC(0)
         pix_x = ctypes.windll.gdi32.GetDeviceCaps(dc, HORZRES)
@@ -87,13 +84,19 @@ def ternary_coord_trans(
     *args: Array1D[np.float64] | Array2D[np.float64],
 ) -> Array2D[np.float64]:
     """Routine to transform ternary coordinates to xy coordinates.
+
     Inputs can either be 3 separate coordinate arrays or a nX3 array
-    The sum of the input coordinates should be one - the routine will normalise the inputs
+    The sum of the input coordinates should be one - the routine will normalise the inputs.
+
+    Parameters
+    ----------
+    *args
+        Either 3 separate coordinate arrays or a single nX3 array.
 
     Returns
     -------
-    np.ndarray
-        Coordinates in nx2 numpy array.
+    Coordinates in nx2 numpy array.
+
     """
     trans_mat = np.array(
         [
@@ -125,16 +128,16 @@ def ternary_coord_trans(
 
 def triangle_transform(xy1: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """
+    Transform triangle coordinates.
 
     Parameters
     ----------
-    xy1 : np.ndarray
+    xy1
         Input coordinates.
 
     Returns
     -------
-    np.ndarray
-        Transformed input.
+    Transformed input.
     """
     xy = np.ones_like(xy1, dtype=float)
     xy[:, 0] = 0.5 + (xy1[:, 0] - 0.5) * (1 - xy1[:, 1])

--- a/src/rock_physics_open/ternary_plots/unconventionals_ternary.py
+++ b/src/rock_physics_open/ternary_plots/unconventionals_ternary.py
@@ -23,30 +23,31 @@ def run_ternary(
 
     Parameters
     ----------
-    quartz : np.ndarray
+    quartz
         Quartz volume fraction [fraction].
-    carb : np.ndarray
+    carb
         Carbonate volume fraction [fraction].
-    clay : np.ndarray
+    clay
         Clay volume fraction [fraction].
-    kero : np.ndarray
+    kero
         Kerogen volume fraction [fraction].
-    phi : np.ndarray
+    phi
         Porosity [fraction].
-    misc : np.ndarray
+    misc
         Property used for colour coding [unknown].
-    misc_log_type : str
+    misc_log_type
         Plot annotation of log used for colour coding.
-    well_name : str
+    well_name
         Plot heading with well name.
-    draw_figures : bool
+    draw_figures
         Decide if figures are drawn or not, default is True.
 
     Returns
     -------
-    tuple
-        lith_class, hard : (np.ndarray, np.ndarray).
-        lith_class: lithology class [int], hardness [float].
+    lith_class
+        Lithology class per sample.
+    hardness
+        Derived hardness value per sample.
     """
     if draw_figures:
         matplotlib.use("TkAgg")

--- a/tests/fluid_model_tests/test_brine_properties.py
+++ b/tests/fluid_model_tests/test_brine_properties.py
@@ -80,9 +80,7 @@ def test_brine_velocity():
 
 
 def test_water_brine_properties_float():
-    """
-    Make sure that input object type is reflected in output type
-    """
+    """Make sure that input object type is reflected in output type."""
     for results in [
         water(temp[0], pres[0]),
         water_density(temp[0], pres[0]),

--- a/tests/fluid_model_tests/test_gas_properties.py
+++ b/tests/fluid_model_tests/test_gas_properties.py
@@ -26,8 +26,6 @@ def test_gas_properties():
 
 
 def test_gas_properties_float():
-    """
-    Make sure that input object type is reflected in output type
-    """
+    """Make sure that input object type is reflected in output type."""
     args = gas_properties(temp[0], pres[0], gr[0])
     assert all(isinstance(arg, float) for arg in args)

--- a/tests/fluid_model_tests/test_oil_properties.py
+++ b/tests/fluid_model_tests/test_oil_properties.py
@@ -100,9 +100,7 @@ def test_live_oil_han_batzle():
 
 
 def test_max_gor_standing():
-    """
-    Snapshot test for max_gor_standing (Standing 1962 inverse bubble-point).
-    """
+    """Snapshot test for max_gor_standing (Standing 1962 inverse bubble-point)."""
     args = max_gor_standing(rho_0, pres, gr, temp)
 
     if not os.path.isfile(get_snapshot_name()) or INITIATE:
@@ -112,10 +110,7 @@ def test_max_gor_standing():
 
 
 def test_max_gor_standing_float():
-    """
-    Verify that max_gor_standing returns a float when all inputs are scalar,
-    and that it is consistent with bp_standing (round-trip).
-    """
+    """Verify that max_gor_standing returns a float when all inputs are scalar, and that it is consistent with bp_standing (round-trip)."""
     result = max_gor_standing(rho_0[0], pres[0], gr[0], temp[0])
     assert isinstance(result, float)
 
@@ -126,9 +121,7 @@ def test_max_gor_standing_float():
 
 
 def test_oil_properties_float():
-    """
-    Make sure that input object type is reflected in output type
-    """
+    """Make sure that input object type is reflected in output type."""
     for results in [
         oil_properties(temp[0], pres[0], rho_0[0], gor[0], gr[0]),
         oil_properties(temp[0], pres[0], rho_0[0], gor[0], gr[0], model_version="BW"),

--- a/tests/machine_learning_utilities_test/test_pressure_models.py
+++ b/tests/machine_learning_utilities_test/test_pressure_models.py
@@ -9,7 +9,6 @@ pytest test_pressure_models.py -v                    # Run all tests
 pytest test_pressure_models.py -m unit              # Run only unit tests
 pytest test_pressure_models.py -m benchmark         # Run only benchmarks
 pytest test_pressure_models.py -k "exponential"     # Run tests matching pattern
-
 """
 
 import os

--- a/tests/t_matrix_model_tests/test_t_matrix_optimisation.py
+++ b/tests/t_matrix_model_tests/test_t_matrix_optimisation.py
@@ -60,27 +60,26 @@ def poly_function(
     e: float,
 ) -> npt.NDArray[np.float64]:
     """
-    Simple function to test the scipy optimisation function curve_fit
+    Simple function to test the scipy optimisation function curve_fit.
 
     Parameters
     ----------
-    x : np.ndarray
+    x_data
         independent variable in polynomial
-    a : float
+    a
         constant
-    b : float
+    b
         first order coefficient
-    c : float
+    c
         second order coefficient
-    d : float
+    d
         third order coefficient
-    e : float
+    e
         fourth order coefficient
 
     Returns
     -------
-    y : np.ndarray
-        polynomial value
+    polynomial value
     """
     return a + b * x_data + c * x_data**2 + d * x_data**3 + e * x_data**4
 

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -233,6 +245,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docstring-parser-fork"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/bf/27f9cab2f0cd1d17a4420572088bbc19f36d726fbcf165edf226a8926dbc/docstring_parser_fork-0.0.14.tar.gz", hash = "sha256:a2743a63d8d36c09650594f7b4ab5b2758fee8629dcf794d1b221b23179baa5c", size = 34551, upload-time = "2025-09-07T17:27:38.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/50/98b146aea0f1cd7531d25f12bea69fa9ce8d1662124f93fb30dc4511b65e/docstring_parser_fork-0.0.14-py3-none-any.whl", hash = "sha256:4c544f234ef2cc2749a3df32b70c437d77888b1099143a1ad5454452c574b9af", size = 43063, upload-time = "2025-09-07T17:27:37.012Z" },
 ]
 
 [[package]]
@@ -825,6 +846,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydoclint"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "docstring-parser-fork" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/58/bb3c7edd2bd06b07d9bbb494e52e2d2d6d53405b166aac531b1a27cef972/pydoclint-0.8.3.tar.gz", hash = "sha256:0c69c0ed92c6f6b5aec2a14371bbd9e0a77980da8e2fa0f708092aa06b3b20b3", size = 186619, upload-time = "2025-11-26T06:53:43.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/6f/cc2b231dc78d8c3aaa674a676db190b8f8071c50134af8f8cf39b9b8e8df/pydoclint-0.8.3-py3-none-any.whl", hash = "sha256:5fc9b82d0d515afce0908cb70e8ff695a68b19042785c248c4f227ad66b4a164", size = 79075, upload-time = "2025-11-26T06:53:42.129Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -958,6 +992,7 @@ dev = [
     { name = "matplotlib-stubs" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
+    { name = "pydoclint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -981,6 +1016,7 @@ dev = [
     { name = "matplotlib-stubs", specifier = "==0.3.11" },
     { name = "pandas-stubs", specifier = "==3.0.0.260204" },
     { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "pydoclint", specifier = "==0.8.3" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.8" },


### PR DESCRIPTION
Standardize all docstrings across the codebase and add tooling to enforce consistency going forward.

Closes #53

## Changes

**Docstring fixes (120 files):**
- Convert Google-style `Args:`/`Returns:` to NumPy-style `Parameters`/`Returns` sections
- Align docstring parameter and return types with function signature type annotations
- Fix parameter order mismatches between docstrings and signatures
- Add missing `Parameters`, `Returns`, and `Raises` sections
- Merge `__init__` docstrings into class-level docstrings
- Rename non-standard `Comments` sections to `Notes`

**Tooling (pyproject.toml, .pre-commit-config.yaml, uv.lock):**
- Add `pydoclint` as dev dependency and pre-commit hook
- Enable ruff pydocstyle (`D`) rules with NumPy convention
- Configure `docstring-code-format = true` in ruff

All checks pass: ruff, basedpyright, pydoclint, pytest (201 tests).