### PR TITLE
fix(t_matrix_models): avoid mutating pressure inputs in carbonate_pressure_model

### DIFF
--- a/src/rock_physics_open/t_matrix_models/carbonate_pressure_substitution.py
+++ b/src/rock_physics_open/t_matrix_models/carbonate_pressure_substitution.py
@@ -7,6 +7,7 @@ import pandas as pd
 from rock_physics_open.equinor_utilities.machine_learning_utilities.run_regression import (
     run_regression,
 )
+from rock_physics_open.equinor_utilities.units import kg_m3_to_g_cc, pa_to_mpa
 
 
 def carbonate_pressure_model(
@@ -95,11 +96,11 @@ def carbonate_pressure_model(
     # Porosity in percent
     phi_percent = phi * 100.0
     # Pressure in MPa
-    pres_overburden *= 1.0e-6
-    pres_formation *= 1.0e-6
-    pres_form_depleted *= 1.0e-6
+    pres_overburden = pa_to_mpa(pres_overburden)
+    pres_formation = pa_to_mpa(pres_formation)
+    pres_form_depleted = pa_to_mpa(pres_form_depleted)
     # Density in g/cm^3
-    rho_dry *= 1.0e-3
+    rho_dry = kg_m3_to_g_cc(rho_dry)
 
     # Generate DataFrame with necessary inputs for in situ and depleted cases
     input_dict = {


### PR DESCRIPTION
## Summary

`carbonate_pressure_model` previously mutated its `pres_overburden`, `pres_formation`, and `pres_form_depleted` input arrays in-place via `*= 1.0e-6` when converting from Pa to MPa. Callers reusing the same array (e.g. across multiple tests or successive calls) would silently get incorrect results — see #141 for the full reproduction.

## Changes

- Rebind pressure and density locals to new arrays instead of using `*=`, so caller-provided arrays are no longer mutated.
- Use the conversion helpers `pa_to_mpa` and `kg_m3_to_g_cc` from `equinor_utilities.units` for readability.

## Validation

- `uv run pytest` — 186 passed.

Fixes #141