### PR TITLE
fix(classification): correct poly_class type annotations

### DIFF
--- a/src/rock_physics_open/equinor_utilities/classification_functions/poly_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/poly_class.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import matplotlib.path as mplpath
 import numpy as np
 import numpy.typing as npt
@@ -5,9 +7,9 @@ import numpy.typing as npt
 
 def poly_class(
     train_data: npt.NDArray[np.float64],
-    polygons: npt.NDArray[np.float64],
-    labels: npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
+    polygons: Sequence[npt.NDArray[np.float64]] | npt.NDArray[np.float64],
+    labels: Sequence[int] | npt.NDArray[np.integer],
+) -> npt.NDArray[np.integer]:
     """
     Points within the polygons are assigned to class labels.
 


### PR DESCRIPTION
Fixes #146

The type annotations on `poly_class` did not match the actual accepted inputs and return value, forcing downstream `# pyright: ignore[reportArgumentType]` suppressions.

## Changes

- `polygons`: `NDArray[float64]` → `Sequence[NDArray[float64]] | NDArray[float64]` (it is iterated as a ragged sequence of per-polygon vertex arrays, but also accepts a uniform 3D array)
- `labels`: `NDArray[float64]` → `Sequence[int] | NDArray[integer]` (used as class IDs assigned into an int array)
- Return: `NDArray[float64]` → `NDArray[integer]` (the function returns `np.zeros(...).astype("int")`)

## Validation

- `uv run basedpyright`: 0 errors
- `uv run pytest`: 186 passed