### PR TITLE
refactor!: resolve pyright ignores for first-party code

### DIFF
--- a/src/rock_physics_open/equinor_utilities/anisotropy.py
+++ b/src/rock_physics_open/equinor_utilities/anisotropy.py
@@ -48,11 +48,6 @@ def c_ij_2_c_factors(
     c66
             All 1-dimensional of same length.
     """
-    if not isinstance(cij, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance]
-        try:  # pyright: ignore[reportUnreachable]
-            cij = np.array(cij, dtype=float)  # pyright: ignore[reportUnreachable]
-        except ValueError:
-            print("Input data can't be transformed into a NumPy array")  # pyright: ignore[reportUnreachable]
     try:
         num_samp = int(cij.size / 36)
         cij = cij.reshape((6, 6, num_samp))
@@ -156,11 +151,6 @@ def c_ij_2_thomsen(
             Thomsen's parameters.
     """
     # C matrix should be 6x6
-    if not isinstance(c, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance]
-        try:  # pyright: ignore[reportUnreachable]
-            c = np.array(c, dtype=float)  # pyright: ignore[reportUnreachable]
-        except ValueError:
-            print("Input data can't be transformed into a NumPy array")  # pyright: ignore[reportUnreachable]
     try:
         num_samp = int(c.size / 36)
         c = c.reshape((6, 6, num_samp))

--- a/src/rock_physics_open/equinor_utilities/classification_functions/class_stats.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/class_stats.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 
@@ -6,7 +8,7 @@ NULL_CLASS = 0
 
 def gen_class_stats(
     obs: npt.NDArray[np.float64],
-    class_val: npt.NDArray[np.int64],
+    class_val: npt.NDArray[Any],
 ) -> tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
@@ -51,10 +53,7 @@ def gen_class_stats(
     """
     n, m = obs.shape
     # Find number of classes. If class_val input is not integer, raise an exception
-    if not (
-        isinstance(class_val, np.ndarray)  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        and issubclass(class_val.dtype.type, np.integer)  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-    ):
+    if not issubclass(class_val.dtype.type, np.integer):
         raise ValueError(f"{__file__}: class values are not discrete numbers")
 
     class_id, class_counts = np.unique(class_val, return_counts=True)

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
@@ -50,13 +50,9 @@ def dim_check_vector(
     Raises
     ------
     ValueError
-        If input type is not supported.
+        If `force_type` conversion fails or if inputs have incompatible lengths.
     """
     single_types = (np.ndarray, pd.DataFrame)
-    iterable_types = (list, tuple)
-    allowed_types = single_types + iterable_types
-    if not isinstance(args, allowed_types):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        raise ValueError("dim_check_vector: unknown input type: {}".format(type(args)))  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
 
     # Single array or dataframe is just returned
     if isinstance(args, single_types):

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
@@ -48,8 +48,6 @@ def filter_input_log(
     type_error = "filter_input_log: unknown input data type: {}".format(type(args))
     size_error = "filter_input_log: inputs of different length"
 
-    if not isinstance(args, (list, tuple, np.ndarray, pd.DataFrame)):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        raise ValueError(type_error)  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
     # Make sure that 'args' is iterable
     if isinstance(args, (np.ndarray, pd.DataFrame)):
         args = [args]

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
@@ -49,21 +49,11 @@ def filter_output(
         logs.loc[idx] = inp_df
         return logs
 
-    if not isinstance(inp_log, (list, tuple, np.ndarray, pd.DataFrame)):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        raise ValueError(  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
-            "filter_output: unknown input data type: {}".format(type(inp_log))
-        )
-    if not isinstance(idx_inp, (list, np.ndarray)):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        raise ValueError(  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
-            "filter_output: unknown filter array data type: {}".format(type(idx_inp))
-        )
-
     # Make iterable in case of single input
     if isinstance(inp_log, (np.ndarray, pd.DataFrame)):
         inp_log = [inp_log]
 
-    if isinstance(idx_inp, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-        idx_inp_ = [idx_inp]
+    idx_inp_ = [idx_inp]
 
     # Possible to simplify?
     if len(idx_inp_) != len(inp_log):
@@ -80,7 +70,7 @@ def filter_output(
     for this_idx, this_log in zip(idx_inp_, inp_log):
         if isinstance(this_log, np.ndarray):
             return_logs.append(_expand_array(this_idx, this_log))
-        elif isinstance(this_log, pd.DataFrame):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
+        else:
             return_logs.append(_expand_df(this_idx, this_log))
 
     return return_logs

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
@@ -69,8 +69,6 @@ class ExponentialPressureModel(BasePressureModel):
         ValueError
             If input format is invalid.
         """
-        if not isinstance(inp_arr, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-            raise ValueError("Input must be numpy ndarray.")  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
         if inp_arr.ndim != 2 or inp_arr.shape[1] != 3:
             raise ValueError(
                 "Input must be (n,3): [velocity, p_eff_in_situ, p_eff_depleted]"

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
@@ -61,8 +61,6 @@ class PolynomialPressureModel(BasePressureModel):
         ValueError
             If input format is invalid.
         """
-        if not isinstance(inp_arr, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-            raise ValueError("Input must be numpy ndarray.")  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
         if inp_arr.ndim != 2 or inp_arr.shape[1] != 3:
             raise ValueError(
                 "Input must be (n,3): [velocity, p_eff_in_situ, p_eff_depleted]"

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
@@ -120,8 +120,6 @@ class SigmoidalPressureModel(BasePressureModel):
         ValueError
             If input format is invalid.
         """
-        if not isinstance(inp_arr, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | Kept for backward compatibility
-            raise ValueError("Input must be numpy ndarray.")  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
         if inp_arr.ndim != 2 or inp_arr.shape[1] != 3:
             raise ValueError(
                 "Input must be (n,3): [porosity, p_eff_in_situ, p_eff_depleted]"

--- a/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
+++ b/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import sys
 from pathlib import Path
-from typing import Any, Literal, Required, TypedDict, cast
+from typing import Any, Literal, Required, TypedDict, assert_never, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -185,6 +185,20 @@ class OptParamsDict(TypedDict, total=False):
     phi_c: float
 
 
+class ExpOptParamsDict(TypedDict):
+    """Fully-typed view of ``OptParamsDict`` for the ``exp`` optimisation variant."""
+
+    well_name: str
+    opt_ver: OptType
+    opt_vec: npt.NDArray[np.float64]
+    k_carb: float
+    mu_carb: float
+    rho_carb: float
+    k_sh: float
+    mu_sh: float
+    rho_sh: float
+
+
 class ParameterTranslationDict(TypedDict):
     opt_ver: str
     no_incl_sets: str
@@ -249,11 +263,6 @@ def save_opt_params(
         File to save results to, by default 'opt_params.pkl'.
     well_name
         Name of the well which is used in optimisation, by default 'Unknown well'.
-
-    Raises
-    ------
-    ValueError
-        If unknown optimisation opt_type.
     """
     # Save the optimal parameters with info
     if opt_type == "min":  # optimisation with mineral input from well
@@ -310,9 +319,7 @@ def save_opt_params(
             "opt_vec": opt_params,
         }
     else:
-        raise ValueError(  # pyright: ignore[reportUnreachable] # kept for backward compatibility
-            "save_opt_params: unknown optimisation opt_type: {}".format(opt_type)
-        )
+        assert_never(opt_type)
 
     with open(file_name, "wb") as file_out:
         pickle.dump(opt_param_dict, file_out)

--- a/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal, assert_never, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -92,8 +92,6 @@ def reflectivity(
     elif model == "SmithGidlow":
         refl_coef = std_functions.smith_gidlow(vp, vs, rho, theta_, k_)
     else:
-        raise ValueError(  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
-            f'{__file__}: unknown model: {model}, should be one of "AkiRichards", "SmithGidlow"'
-        )
+        assert_never(model)
 
     return refl_coef, idx_inp

--- a/src/rock_physics_open/equinor_utilities/various_utilities/types.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/types.py
@@ -41,8 +41,8 @@ class TMatrixCallable(Protocol):
         tau: Any,
         frequency: float,
         angle: float,
-        frac_inc_con: Array1D[np.float64],
-        frac_inc_ani: Array1D[np.float64],
+        frac_inc_con: Array1D[np.float64] | float,
+        frac_inc_ani: Array1D[np.float64] | float,
     ) -> tuple[
         Array1D[np.float64],
         Array1D[np.float64],

--- a/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
@@ -69,7 +69,6 @@ def vp_vs_rho_stats(
         rho_estimated,
         set_names=estimated_set_names,
         well_names=well_names,
-        file_mode=file_mode,
     )
 
     est_frame_columns = [
@@ -138,7 +137,6 @@ def _verify(
     *args: npt.NDArray[np.float64] | list[npt.NDArray[np.float64]],
     set_names: list[str],
     well_names: list[str],
-    file_mode: Literal["a", "w"],
 ):
     """Verify that arguments are either numpy arrays or lists of numpy arrays.
 
@@ -150,8 +148,6 @@ def _verify(
         Names of the sets.
     well_names
         Names of the wells.
-    file_mode
-        File write mode.
 
     """
     # Verify that args are either numpy arrays or list of arrays
@@ -159,13 +155,9 @@ def _verify(
         if isinstance(arg, np.ndarray):
             arg = [arg]
         for this_arg in arg:
-            if not isinstance(this_arg, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | For backward compatibility
-                raise ValueError(f"{__file__}: input not numpy array: {type(arg)}")
             if np.any(np.isnan(this_arg)):
                 raise ValueError(f"{__file__}: input contains NaNs")
             if np.any(np.isinf(this_arg)):
                 raise ValueError(f"{__file__}: input contains Infs")
         if not len(arg) == len(set_names) == len(well_names):
             raise ValueError(f"{__file__}: mismatch in argument lengths")
-    if not (file_mode == "a" or file_mode == "w"):
-        raise ValueError(f'{__file__}: file_mode must be one of ["a", "w"]')  # pyright: ignore[reportUnreachable] | For backward compatibility

--- a/src/rock_physics_open/sandstone_models/patchy_cement_fluid_substitution_model.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_fluid_substitution_model.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, assert_never
 from warnings import warn
 
 import numpy as np
@@ -438,7 +438,7 @@ def _handle_exceptions_part_1(
     elif phi_below_zero == "disregard":
         pass
     else:
-        raise ValueError('unknown argument for parameter "phi_below_zero"')  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
+        assert_never(phi_below_zero)
 
     #  Handling of case 2:
     idx2 = phi_vec > phi_c_const
@@ -448,7 +448,7 @@ def _handle_exceptions_part_1(
     elif phi_above_phi_c == "disregard":
         pass
     else:
-        raise ValueError('unknown argument for parameter "phi_above_phi_c"')  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
+        assert_never(phi_above_phi_c)
 
     # Handling of case 3:
     idx3 = np.logical_or(k_sat > k_min, mu > mu_min)
@@ -459,7 +459,7 @@ def _handle_exceptions_part_1(
     elif k_sat_above_k_min == "disregard":
         pass
     else:
-        raise ValueError('unknown argument for parameter "k_sat_above_k_min"')  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
+        assert_never(k_sat_above_k_min)
     return np.any(np.vstack((idx1, idx2, idx3)), axis=0)
 
 
@@ -503,7 +503,7 @@ def _handle_exceptions_part_2(
     elif below_lower_bound == "disregard":
         idx5 = np.logical_or(idx5k, idx5mu)
     else:
-        raise ValueError('unknown argument for parameter "below_lower_bound"')  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
+        assert_never(below_lower_bound)
 
     # Handling of case 6:
     if above_upper_bound == "snap":
@@ -521,7 +521,7 @@ def _handle_exceptions_part_2(
             np.greater(mu, mu_up, where=~idx_nan, out=None),
         )
     else:
-        raise ValueError('unknown argument for parameter "above_upper_bound"')  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
+        assert_never(above_upper_bound)
 
     # Exception for all cases 1-6:
     return np.any(np.vstack((idx, idx5, idx6, idx_nan)), axis=0)

--- a/src/rock_physics_open/shale_models/shale4_mineral.py
+++ b/src/rock_physics_open/shale_models/shale4_mineral.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal, assert_never, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -119,11 +119,6 @@ def shale_model_4_mineral_dem(
         Shear wave velocity [m/s].
     rho_factor
         Ratio between modelled and observed density [ratio].
-
-    Raises
-    ------
-    ValueError
-        If mod_type is unknown.
     """
     #   tol: DEM model calculation tolerance <= Set as a hardcoded value, not
     #   found to influence the results
@@ -169,9 +164,7 @@ def shale_model_4_mineral_dem(
         )
         rho_mat = f1 * rho1 + f2 * rho2 + f3 * rho3 + f4 * rho4
     else:
-        raise ValueError(
-            f'{__file__}: unknown type: {mod_type}, should be one of "SCA", "VRH"'  # pyright: ignore[reportUnreachable] | Kept for backward compatibility
-        )
+        assert_never(mod_type)
 
     k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp = cast(
         list[npt.NDArray[np.float64]],

--- a/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
+++ b/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
@@ -41,9 +41,9 @@ def parse_t_matrix_inputs(
     Array1D[np.float64],
     Array1D[np.float64],
     Array1D[np.float64],
+    Array2D[np.float64],
+    Array2D[np.float64],
     Array1D[np.float64],
-    Array2D[np.float64],
-    Array2D[np.float64],
     float,
     float,
     Array1D[np.float64],
@@ -303,14 +303,18 @@ def parse_t_matrix_inputs(
     alpha_shape = alpha.shape
     # First make sure that alpha and v have the same number of elements
     try:
-        alpha, v = cast(  # casting since dim_check_vector typing is incomplete
-            list[Array1D[np.float64]],
-            gen_utilities.dim_check_vector((alpha, v), force_type=np.dtype(float)),
+        alpha_flat, v_flat = (
+            cast(  # casting since dim_check_vector typing is incomplete
+                list[Array1D[np.float64]],
+                gen_utilities.dim_check_vector((alpha, v), force_type=np.dtype(float)),
+            )
         )
     except ValueError:
         raise ValueError("t-matrix inputs: {}".format(str(sys.exc_info())))
-    alpha = alpha.reshape(alpha_shape)  # pyright: ignore[reportAssignmentType] | Should be same shape as before
-    v = v.reshape(alpha_shape)  # pyright: ignore[reportAssignmentType] | Should be same shape as before
+    alpha = cast(
+        Array1D[np.float64] | Array2D[np.float64], alpha_flat.reshape(alpha_shape)
+    )
+    v = cast(Array1D[np.float64] | Array2D[np.float64], v_flat.reshape(alpha_shape))
     # If they are 2D arrays, the first dimension should match log_length
     if alpha.ndim == 2:
         if not (alpha_shape[0] == log_length or alpha_shape[0] == 1):
@@ -324,11 +328,13 @@ def parse_t_matrix_inputs(
     elif alpha.ndim == 1:
         alpha = np.tile(alpha.reshape(1, alpha_shape[0]), (log_length, 1))
         v = np.tile(v.reshape(1, alpha_shape[0]), (log_length, 1))
+    alpha = cast(Array2D[np.float64], alpha)
+    v = cast(Array2D[np.float64], v)
     # Check that the number of elements in tau matches dim 1 of alpha
     if isinstance(tau, float):
         tau = np.ones(alpha_shape) * tau
     else:
-        if not tau.ndim == 1 and tau.shape[0] == alpha.shape[1]:  # pyright: ignore[reportGeneralTypeIssues] | alpha is Array2D
+        if not (tau.ndim == 1 and tau.shape[0] == alpha.shape[1]):
             raise ValueError(
                 "t-matrix inputs: number of elements in tau is not matching number of inclusions"
             )
@@ -350,14 +356,14 @@ def parse_t_matrix_inputs(
 
     # 6: Determine case for connected/isolated and isotropic/anisotropic inclusions
     # Assume the most general case: mix of isotropic and anisotropic inclusions and connected and isolated inclusions
-    ctrl_anisotropy = 1
+    ctrl_anisotropy: Literal[0, 1, 2] = 1
     if np.all(frac_inc_ani == 0):
         ctrl_anisotropy = 0  # All isotropic
-        angle = 0
+        angle = 0.0
     elif np.all(frac_inc_ani == 1):
         ctrl_anisotropy = 2  # All anisotropic
 
-    ctrl_connected = 1
+    ctrl_connected: Literal[0, 1, 2] = 1
     # Create case based on amount of connected inclusions
     if np.all(frac_inc_con == 0):
         ctrl_connected = 0  # All isolated
@@ -373,7 +379,7 @@ def parse_t_matrix_inputs(
         phi,
         perm,
         visco,
-        alpha,  # pyright: ignore[reportReturnType] | alpha is Array1D or Array2D
+        alpha,
         v,
         tau,
         frequency,

--- a/src/rock_physics_open/t_matrix_models/t_matrix_C.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_C.py
@@ -23,8 +23,8 @@ def t_matrix_porosity_c_alpha_v(
     tau: Any,
     frequency: float,
     angle: float,
-    frac_inc_con: float,
-    frac_inc_ani: float,
+    frac_inc_con: Array1D[np.float64] | float,
+    frac_inc_ani: Array1D[np.float64] | float,
 ) -> tuple[
     Array1D[np.float64],
     Array1D[np.float64],

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
@@ -10,6 +10,9 @@ from rock_physics_open.equinor_utilities.optimisation_utilities import (
     load_opt_params,
     opt_param_info,
 )
+from rock_physics_open.equinor_utilities.optimisation_utilities.opt_subst_utilities import (
+    ExpOptParamsDict,
+)
 from rock_physics_open.equinor_utilities.various_utilities.types import Array1D
 
 from .curvefit_t_matrix_exp import curvefit_t_matrix_exp
@@ -180,10 +183,11 @@ def run_t_matrix_with_opt_params_exp(
         raise TypeError(
             f"{__file__}: incorrect type of optimal parameter input file, must come from EXP optimisation"
         )
+    opt_dict_exp = cast(ExpOptParamsDict, cast(object, opt_dict))
 
     rho_mod = (
-        (1.0 - vsh) * opt_dict["rho_carb"] * scale_val["rho_carb"]  # pyright: ignore[reportTypedDictNotRequiredAccess] | Should be there for exp
-        + vsh * opt_dict["rho_sh"] * scale_val["rho_sh"]  # pyright: ignore[reportTypedDictNotRequiredAccess] | Should be there for exp
+        (1.0 - vsh) * opt_dict_exp["rho_carb"] * scale_val["rho_carb"]
+        + vsh * opt_dict_exp["rho_sh"] * scale_val["rho_sh"]
     ) * (1.0 - phi) + phi * fl_rho_orig
 
     rho_res = rho_mod - rhob

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
@@ -9,6 +9,9 @@ from rock_physics_open.equinor_utilities.optimisation_utilities import (
     load_opt_params,
     opt_param_info,
 )
+from rock_physics_open.equinor_utilities.optimisation_utilities.opt_subst_utilities import (
+    ExpOptParamsDict,
+)
 from rock_physics_open.equinor_utilities.various_utilities.types import Array1D
 
 from .curvefit_t_matrix_exp import curvefit_t_matrix_exp
@@ -92,10 +95,11 @@ def run_t_matrix_forward_model_with_opt_params_exp(
         raise TypeError(
             f"{__file__}: incorrect type of optimal parameter input file, must come from EXP optimisation"
         )
+    opt_dict_exp = cast(ExpOptParamsDict, cast(object, opt_dict))
 
     rho_mod = (
-        (1.0 - vsh) * opt_dict["rho_carb"] * scale_val["rho_carb"]  # pyright: ignore[reportTypedDictNotRequiredAccess] | Should be there for exp
-        + vsh * opt_dict["rho_sh"] * scale_val["rho_sh"]  # pyright: ignore[reportTypedDictNotRequiredAccess] | Should be there for exp
+        (1.0 - vsh) * opt_dict_exp["rho_carb"] * scale_val["rho_carb"]
+        + vsh * opt_dict_exp["rho_sh"] * scale_val["rho_sh"]
     ) * (1.0 - phi) + phi * fl_rho
     y_shape = (phi.shape[0], 2)
 
@@ -111,8 +115,6 @@ def run_t_matrix_forward_model_with_opt_params_exp(
         ydata_shape=y_shape,
         opt_params=opt_params,
     )
-    if not isinstance(v_mod, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | kept for backwards compatibility
-        raise ValueError(f"{__file__}: no solution to forward model")
     vp_mod, vs_mod = [arr.flatten() for arr in np.split(v_mod, 2, axis=1)]
     vpvs_mod = vp_mod / vs_mod
     ai_mod = vp_mod * rho_mod

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
@@ -119,8 +119,6 @@ def run_t_matrix_forward_model_with_opt_params_petec(
         axis=1,
     )
     v_mod = gen_mod_routine(opt_fcn, x_data, y_shape, opt_params)
-    if not isinstance(v_mod, np.ndarray):  # pyright: ignore[reportUnnecessaryIsInstance] | kept for backwards compatibility
-        raise ValueError(f"{__file__}: no solution to forward model")
     vp_mod, vs_mod = [arr.flatten() for arr in np.split(v_mod, 2, axis=1)]
     vpvs_mod = vp_mod / vs_mod
     ai_mod = vp_mod * rho_mod

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/array_functions.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/array_functions.py
@@ -47,7 +47,7 @@ def array_matrix_mult(
     Raises
     ------
     ValueError
-        If input is not a list or tuple or if there is a mismatch in input shape/dimension.
+        If there is a mismatch in input shape/dimension.
     """
     if len(args) == 0:
         raise ValueError(f"{__name__}: no input arguments provided")
@@ -56,11 +56,7 @@ def array_matrix_mult(
 
     arg_shape: list[tuple[int, ...]] = []
     for i in range(len(args)):
-        if not (
-            isinstance(args[i], np.ndarray)  # pyright: ignore[reportUnnecessaryIsInstance] | kept for backwards compatibility
-            and args[i].ndim == 3
-            and args[i].shape[1] == args[i].shape[2]
-        ):
+        if not (args[i].ndim == 3 and args[i].shape[1] == args[i].shape[2]):
             raise ValueError(
                 f"{__name__}: mismatch in inputs variables dimension/shape"
             )

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 
@@ -95,7 +95,7 @@ def calc_pressure_vec(
 
     def _new_values(
         k: Array4D[np.float64],
-        sum_k: Array2D[np.float64],
+        sum_k: Array1D[np.float64],
         a: Array2D[np.float64],
         v: Array2D[np.float64],
         d_p: float,
@@ -148,7 +148,7 @@ def calc_pressure_vec(
         frac_ani=frac_ani,
     )
     # Find the sum in the eq. 21 Jakobsen and Johansen 2005
-    sum_kd = 0.0
+    sum_kd: Array1D[np.float64] = np.zeros(v_iso.shape[0])
     if ctrl != 2 and kd_eff_isolated is not None:
         count_isolated = kd_eff_isolated.shape[3]
         for j in range(count_isolated):
@@ -171,7 +171,7 @@ def calc_pressure_vec(
     if ctrl != 2 and kd_eff_isolated is not None:
         v_n_isolated, alpha_n_isolated, _, _ = _new_values(
             k=kd_eff_isolated,
-            sum_k=sum_kd,  # pyright: ignore[reportArgumentType] | sum_kd is Array2D after the loop
+            sum_k=sum_kd,
             a=alpha_iso,
             v=v_iso,
             d_p=d_p,
@@ -182,7 +182,7 @@ def calc_pressure_vec(
     if ctrl != 0 and kd_eff_connected is not None:
         v_n_connected, alpha_n_connected, tau_n_out, gamma_n_out = _new_values(
             k=kd_eff_connected,
-            sum_k=sum_kd,  # pyright: ignore[reportArgumentType] | sum_kd is Array2D after the loop
+            sum_k=sum_kd,
             a=alpha_con,
             v=v_con,
             d_p=d_p,
@@ -190,11 +190,21 @@ def calc_pressure_vec(
             g=gamma,
         )
 
-    return (  # pyright: ignore[reportReturnType] | #TODO: This should be fixed properly
-        alpha_n_connected,
-        v_n_connected,
-        alpha_n_isolated,
-        v_n_isolated,
-        tau_n_out,
-        gamma_n_out,
+    return cast(
+        tuple[
+            Array2D[np.float64],
+            Array2D[np.float64],
+            Array2D[np.float64],
+            Array2D[np.float64],
+            Array1D[np.float64],
+            Array2D[np.float64],
+        ],
+        (
+            alpha_n_connected,
+            v_n_connected,
+            alpha_n_isolated,
+            v_n_isolated,
+            tau_n_out,
+            gamma_n_out,
+        ),
     )

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_z.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_z.py
@@ -52,7 +52,7 @@ def calc_z_vec(
     """
     i2_i2, log_length, alpha_length = check_and_tile(s0, td)
 
-    sum_z = 0.0
+    sum_z = np.zeros((log_length, 6, 6), dtype="complex128")
     z = np.zeros((log_length, 6, 6, alpha_length), dtype="complex128")
     z_bar = np.zeros((log_length, 6, 6, alpha_length), dtype="complex128")
 
@@ -67,14 +67,14 @@ def calc_z_vec(
             s0,
             i2_i2,
             s0,
-            sum_z,  # pyright: ignore[reportArgumentType] | sum_z is 3D array after summation
+            sum_z,
         )
         z_bar[:, :, :, j] = array_matrix_mult(
             td_bar[:, :, :, j],
             s0,
             i2_i2,
             s0,
-            sum_z,  # pyright: ignore[reportArgumentType] | sum_z is 3D array after summation
+            sum_z,
         )
 
     return z, z_bar

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/velocity_vti_angles.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/velocity_vti_angles.py
@@ -36,7 +36,6 @@ def velocity_vti_angles_vec(
     if not (
         c_eff.ndim == 3
         and rho_eff.ndim == 1
-        and isinstance(angle, (float, int))  # pyright: ignore[reportUnnecessaryIsInstance] | kept for backwards compatibility
         and (c_eff.shape[0] == rho_eff.shape[0] and c_eff.shape[1] == c_eff.shape[2])
     ):
         raise ValueError("velocity_vti_angles: inconsistencies in input shapes")

--- a/tests/machine_learning_utilities_test/test_pressure_models.py
+++ b/tests/machine_learning_utilities_test/test_pressure_models.py
@@ -1,4 +1,3 @@
-# ruff: noqa: UP034
 """
 Comprehensive pytest test suite for pressure sensitivity models.
 
@@ -87,7 +86,6 @@ def invalid_input_data() -> dict[str, Any]:
     """Provide various invalid input formats for testing."""
     rng = np.random.default_rng(42)
     return {
-        "wrong_type": [[1, 2, 3], [4, 5, 6]],  # List instead of ndarray
         "wrong_dimensions": np.array([1, 2, 3, 4, 5]),  # 1D instead of 2D
         "wrong_columns_exp": rng.random((10, 4)),  # 4 columns instead of 3
         "empty_array": np.empty((0, 3)),  # Empty array
@@ -121,7 +119,6 @@ class TestExponentialPressureModel:
     ):
         """Test validation with invalid input formats."""
         test_cases = [
-            ("wrong_type", "Input must be numpy ndarray."),
             ("wrong_dimensions", "Input must be \\(n,3\\)"),
             ("wrong_columns_exp", "Input must be \\(n,3\\)"),
             ("empty_array", None),  # Empty array might be valid


### PR DESCRIPTION
## Summary

Replace targeted pyright ignore comments with proper type fixes across the codebase. Pyright ignore comments reduced from **63 to 11** (remaining ones are all third-party stub limitations — scipy, matplotlib).

## Changes

- Use `typing.assert_never` for exhaustive `Literal` checks instead of defensive `ValueError` + `reportUnreachable` ignore
- Remove redundant `isinstance` runtime checks on arguments already annotated with concrete types
- Correct return-type annotations in `parse_t_matrix_inputs` and align `TMatrixCallable` protocol with `t_matrix_porosity_c_alpha_v`
- Use `cast()` via `object` for `TypedDict` `NotRequired` access in `t_matrix_opt_forward_model_exp` / `t_matrix_opt_fluid_sub_exp`
- Initialize accumulators with their final array shape (`calc_z.sum_z`, `calc_pressure.sum_kd`) rather than `0.0` floats
- Widen `class_val` dtype in `gen_class_stats` to `npt.NDArray[Any]` so the runtime integer check is meaningful

## Breaking changes

Several defensive runtime type checks that raised `ValueError` on wrongly-typed inputs have been removed. Callers that previously passed lists / tuples to functions annotated as requiring `np.ndarray` will now fail later with less descriptive errors. **The public API input type annotations are unchanged**, so properly typed callers are unaffected.

Functions that no longer raise `ValueError` for wrong input types:

- `equinor_utilities.gen_utilities.filter_input_log`
- `equinor_utilities.gen_utilities.filter_output`
- `equinor_utilities.gen_utilities.dim_check_vector`
- `equinor_utilities.anisotropy.c_ij_2_c_factors`
- `equinor_utilities.anisotropy.cij_2_thomsen` (`c` argument)
- `equinor_utilities.classification_functions.gen_class_stats` (`class_val` argument; dtype check still raises)
- `equinor_utilities.various_utilities.vp_vs_rho_set_statistics` (`file_mode` validation removed — relies on `Literal` type)
- `machine_learning_utilities.ExponentialPressureModel.validate_input`
- `machine_learning_utilities.PolynomialPressureModel.validate_input`
- `machine_learning_utilities.SigmoidalPressureModel.validate_input`
- `t_matrix_models.t_matrix_vector.array_functions.array_matrix_mult`
- `t_matrix_models.t_matrix_vector.velocity_vti_angles`

## Validation

- `uv run basedpyright`: 0 errors, 0 warnings
- `uv run pytest`: 186 passed
- `uv run pre-commit run --all-files`: all hooks pass

## Review feedback addressed (commit 4dea20e)

- Fixed operator-precedence bug in `parse_t_matrix_inputs.py` tau shape guard.
- Corrected `compare_snapshots.py` mismatch error message to report `len(return_test_obj)`.
- Removed obsolete `Raises: ValueError` entries from docstrings of `save_opt_params`, `shale_4_mineral_model`, and `array_matrix_mult`.
- Updated `dim_check_vector` docstring to describe current `Raises` behaviour.
- `calc_pressure_vec` return-type widening deferred to #153 (requires caller refactor).
