### PR TITLE
refactor: remove unnecessary cast() calls around gen_utilities

### DIFF
--- a/src/rock_physics_open/equinor_utilities/anisotropy.py
+++ b/src/rock_physics_open/equinor_utilities/anisotropy.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -92,9 +90,8 @@ def cfactors2cij(
     -------
     A 6x6x(number of samples) stiffness tensor.
     """
-    c11, c12, c13, c33, c44, c66 = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((c11, c12, c13, c33, c44, c66)),
+    c11, c12, c13, c33, c44, c66 = gen_utilities.dim_check_vector(
+        (c11, c12, c13, c33, c44, c66)
     )
 
     num_samp = c11.shape[1]
@@ -233,9 +230,8 @@ def thomsen_2_c_ij(
     c66
         Elastic stiffness component c66.
     """
-    alpha, beta, gamma, delta, epsilon = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((alpha, beta, gamma, delta, epsilon)),
+    alpha, beta, gamma, delta, epsilon = gen_utilities.dim_check_vector(
+        (alpha, beta, gamma, delta, epsilon)
     )
 
     c33 = rho * alpha**2

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/dim_check_vector.py
@@ -7,9 +7,17 @@ import pandas as pd
 
 @overload
 def dim_check_vector(
+    args: tuple[npt.NDArray[np.float64] | float | int, ...]
+    | list[npt.NDArray[np.float64] | float | int],
+    force_type: np.dtype[np.float64] | None = ...,
+) -> list[npt.NDArray[np.float64]]: ...
+
+
+@overload
+def dim_check_vector(
     args: list[Any] | tuple[Any, ...],
     force_type: np.dtype | None = ...,
-) -> list[npt.NDArray[Any] | pd.DataFrame]: ...
+) -> list[Any]: ...
 
 
 @overload
@@ -29,7 +37,7 @@ def dim_check_vector(
 def dim_check_vector(
     args: list[Any] | tuple[Any, ...] | npt.NDArray[Any] | pd.DataFrame,
     force_type: np.dtype | None = None,
-) -> npt.NDArray[Any] | pd.DataFrame | list[npt.NDArray[Any] | pd.DataFrame]:
+) -> npt.NDArray[Any] | pd.DataFrame | list[Any]:
     """
     Check that all inputs are of the same (one-dimensional) size.
 

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_input.py
@@ -1,5 +1,5 @@
 from sys import byteorder
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -8,13 +8,33 @@ import pandas as pd
 WRONG_BYTEORDER = ">" if byteorder == "little" else "<"
 
 
+@overload
+def filter_input_log(
+    args: tuple[npt.NDArray[np.float64], ...] | list[npt.NDArray[np.float64]],
+    working_int: npt.NDArray[Any] | None = ...,
+    negative: bool = ...,
+    no_zero: bool = ...,
+    positive: bool = ...,
+) -> tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]]: ...
+
+
+@overload
+def filter_input_log(
+    args: list[Any] | tuple[Any, ...] | npt.NDArray[Any] | pd.DataFrame,
+    working_int: npt.NDArray[Any] | None = ...,
+    negative: bool = ...,
+    no_zero: bool = ...,
+    positive: bool = ...,
+) -> tuple[npt.NDArray[np.bool_], list[Any]]: ...
+
+
 def filter_input_log(
     args: list[Any] | tuple[Any, ...] | npt.NDArray[Any] | pd.DataFrame,
     working_int: npt.NDArray[Any] | None = None,
     negative: bool = False,
     no_zero: bool = False,
     positive: bool = True,
-) -> tuple[npt.NDArray[np.bool_], list[npt.NDArray[Any] | pd.DataFrame]]:
+) -> tuple[npt.NDArray[np.bool_], list[Any]]:
     """
     Check for valid input values in numpy arrays or pandas data frames.
 

--- a/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
+++ b/src/rock_physics_open/equinor_utilities/gen_utilities/filter_output.py
@@ -1,17 +1,28 @@
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
 
+@overload
 def filter_output(
     idx_inp: npt.NDArray[np.bool_],
-    inp_log: list[npt.NDArray[Any] | pd.DataFrame]
-    | tuple[npt.NDArray[Any] | pd.DataFrame, ...]
-    | npt.NDArray[Any]
-    | pd.DataFrame,
-) -> list[npt.NDArray[Any] | pd.DataFrame]:
+    inp_log: tuple[npt.NDArray[np.float64], ...] | list[npt.NDArray[np.float64]],
+) -> list[npt.NDArray[np.float64]]: ...
+
+
+@overload
+def filter_output(
+    idx_inp: npt.NDArray[np.bool_],
+    inp_log: list[Any] | tuple[Any, ...] | npt.NDArray[Any] | pd.DataFrame,
+) -> list[Any]: ...
+
+
+def filter_output(
+    idx_inp: npt.NDArray[np.bool_],
+    inp_log: list[Any] | tuple[Any, ...] | npt.NDArray[Any] | pd.DataFrame,
+) -> list[Any]:
     """
     Function to restore outputs from a plugin to original length and with values at correct positions.
 

--- a/src/rock_physics_open/equinor_utilities/std_functions/gassmann.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/gassmann.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -31,10 +30,7 @@ def gassmann(
     -------
     Bulk modulus for saturated rock [Pa].
     """
-    k_dry, por, k_fl, k_min = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k_dry, por, k_fl, k_min)),
-    )
+    k_dry, por, k_fl, k_min = dim_check_vector((k_dry, por, k_fl, k_min))
 
     idx = np.logical_or(k_dry == k_min, por == 0)
     k_sat = np.ones(k_dry.shape) * np.nan
@@ -78,9 +74,8 @@ def gassmann2(
     -------
     Bulk modulus of rock saturated with replaced fluid [Pa].
     """
-    k_sat_1, k_fl_1, k_fl_2, por, k_min = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k_sat_1, k_fl_1, k_fl_2, por, k_min)),
+    k_sat_1, k_fl_1, k_fl_2, por, k_min = dim_check_vector(
+        (k_sat_1, k_fl_1, k_fl_2, por, k_min)
     )
 
     idx = np.any(
@@ -135,10 +130,7 @@ def gassmann_dry(
     -------
     Dry rock bulk modulus [Pa].
     """
-    k_sat, por, k_fl, k_min = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k_sat, por, k_fl, k_min)),
-    )
+    k_sat, por, k_fl, k_min = dim_check_vector((k_sat, por, k_fl, k_min))
 
     idx = np.any(np.array([k_sat == k_min, por == 0, k_fl == k_min]), axis=0)
     k_dry = np.ones(k_sat.shape)

--- a/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -120,10 +120,7 @@ def hashin_shtrikman_walpole(
         effective shear modulus [Pa].
 
     """
-    k1, mu1, k2, mu2, f1 = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k1, mu1, k2, mu2, f1)),
-    )
+    k1, mu1, k2, mu2, f1 = dim_check_vector((k1, mu1, k2, mu2, f1))
     if bound.lower() not in ["lower", "upper"]:
         raise ValueError(f'{__file__}: bound must be one of "lower" or "upper"')
 
@@ -194,12 +191,11 @@ def multi_hashin_shtrikman(
             "multi_hashin_shtrikman: inputs not vectors of k, mu and fraction for each mineral"
         )
 
-    k_arr = np.array(coeffs[::3])
-    mu_arr = np.array(coeffs[1::3])
-    f = np.array(coeffs[2::3])
-    if not np.all(
-        cast(npt.NDArray[np.float64], np.around(np.sum(f, axis=0), decimals=6)) == 1.0
-    ):
+    k_arr = np.array(coeffs[::3], dtype=np.float64)
+    mu_arr = np.array(coeffs[1::3], dtype=np.float64)
+    f = np.array(coeffs[2::3], dtype=np.float64)
+    f_sum = np.around(np.sum(f, axis=0, dtype=np.float64), decimals=6)
+    if not np.all(f_sum == 1.0):
         raise ValueError("multi_hashin_shtrikman: all fractions do not add up to 1.0")
 
     if mode.lower() not in ["average", "upper", "lower"]:

--- a/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -35,9 +35,10 @@ def disp_result_stats(
             text_justify: list[Literal["center", "left"]] = ["center", "left"]
             text_weight: list[str] = ["bold", "normal"]
             for i in range(no_rows):
-                weigh = text_weight[cast(int, np.sign(i))]
+                sign_i = int(np.sign(i))
+                weigh = text_weight[sign_i]
                 for j in range(no_cols):
-                    just = text_justify[cast(int, np.sign(i))]
+                    just = text_justify[sign_i]
                     max_len = np.max(str_len(info[:, j]))
                     self.e: Entry = Entry(
                         tk_root,

--- a/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/reflectivity.py
@@ -1,4 +1,4 @@
-from typing import Literal, assert_never, cast
+from typing import Literal, assert_never
 
 import numpy as np
 import numpy.typing as npt
@@ -43,17 +43,13 @@ def reflectivity(
     idx_inp
         Index to accepted part of the input arrays [bool].
     """
-    vp, vs, rho, theta_, k_ = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((vp_inp, vs_inp, rho_inp, theta, k)),
+    vp, vs, rho, theta_, k_ = gen_utilities.dim_check_vector(
+        (vp_inp, vs_inp, rho_inp, theta, k)
     )
 
-    idx_inp, (vp, vs, rho, theta_, k_) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log(
-            [vp, vs, rho, theta_, k_],
-            positive=True,
-        ),
+    idx_inp, (vp, vs, rho, theta_, k_) = gen_utilities.filter_input_log(
+        [vp, vs, rho, theta_, k_],
+        positive=True,
     )
 
     if np.any(~idx_inp):

--- a/src/rock_physics_open/sandstone_models/cemented_shalysand_sandyshale_models.py
+++ b/src/rock_physics_open/sandstone_models/cemented_shalysand_sandyshale_models.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -146,29 +144,26 @@ def cemented_shaly_sand_sandy_shale_model(
         p_eff_mud,
         shale_frac,
         frac_cem_,
-    ) = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector(
-            (
-                k_sst,
-                mu_sst,
-                rho_sst,
-                k_cem,
-                mu_cem,
-                rho_cem,
-                k_mud,
-                mu_mud,
-                rho_mud,
-                k_fl_sst,
-                rho_fl_sst,
-                k_fl_mud,
-                rho_fl_mud,
-                phi,
-                p_eff_mud,
-                shale_frac,
-                frac_cem,
-            )
-        ),
+    ) = gen_utilities.dim_check_vector(
+        (
+            k_sst,
+            mu_sst,
+            rho_sst,
+            k_cem,
+            mu_cem,
+            rho_cem,
+            k_mud,
+            mu_mud,
+            rho_mud,
+            k_fl_sst,
+            rho_fl_sst,
+            k_fl_mud,
+            rho_fl_mud,
+            phi,
+            p_eff_mud,
+            shale_frac,
+            frac_cem,
+        )
     )
     (
         idx_phi,
@@ -193,32 +188,29 @@ def cemented_shaly_sand_sandy_shale_model(
             _,
             _,
         ),
-    ) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log(
-            (
-                k_sst,
-                mu_sst,
-                rho_sst,
-                k_cem,
-                mu_cem,
-                rho_cem,
-                k_mud,
-                mu_mud,
-                rho_mud,
-                k_fl_sst,
-                rho_fl_sst,
-                k_fl_mud,
-                rho_fl_mud,
-                phi,
-                p_eff_mud,
-                shale_frac,
-                frac_cem_,
-                phi_c_sst - frac_cem - phi,
-                phi - phi_intr_mud,
-            ),
-            no_zero=False,
+    ) = gen_utilities.filter_input_log(
+        (
+            k_sst,
+            mu_sst,
+            rho_sst,
+            k_cem,
+            mu_cem,
+            rho_cem,
+            k_mud,
+            mu_mud,
+            rho_mud,
+            k_fl_sst,
+            rho_fl_sst,
+            k_fl_mud,
+            rho_fl_mud,
+            phi,
+            p_eff_mud,
+            shale_frac,
+            frac_cem_,
+            phi_c_sst - frac_cem - phi,
+            phi - phi_intr_mud,
         ),
+        no_zero=False,
     )
     # Reduce range of porosity by frac_cem
     phi_c = phi_c_sst - frac_cem
@@ -236,10 +228,7 @@ def cemented_shaly_sand_sandy_shale_model(
     # log.  Make sure that it is of the same length as the other
 
     # Expand the needed variables from float to numpy array
-    phi, phi_intr_mud_ = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((phi, phi_intr_mud)),
-    )
+    phi, phi_intr_mud_ = gen_utilities.dim_check_vector((phi, phi_intr_mud))
 
     vp_sat_mud, vs_sat_mud, rho_b_mud, _, _ = friable_model(
         k_min=k_mud,
@@ -339,9 +328,8 @@ def cemented_shaly_sand_sandy_shale_model(
     vp, vs, ai, vpvs = std_functions.velocity(k=k, mu=mu, rhob=rhob)
 
     # Restore original length
-    vp, vs, rhob, ai, vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.filter_output(idx_phi, (vp, vs, rhob, ai, vpvs)),
+    vp, vs, rhob, ai, vpvs = gen_utilities.filter_output(
+        idx_phi, (vp, vs, rhob, ai, vpvs)
     )
 
     return vp, vs, rhob, ai, vpvs

--- a/src/rock_physics_open/sandstone_models/constant_cement_models.py
+++ b/src/rock_physics_open/sandstone_models/constant_cement_models.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, overload
+from typing import Literal, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -221,9 +221,8 @@ def constant_cement_model_dry(
     """
     # First check if there are input values that are unphysical, i.e. negative values, separate between dry and
     # saturated rock properties. Use the filter_input_log function to identify these values
-    idx, (k_min, mu_min, k_cem, mu_cem, phi) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log((k_min, mu_min, k_cem, mu_cem, phi)),
+    idx, (k_min, mu_min, k_cem, mu_cem, phi) = gen_utilities.filter_input_log(
+        (k_min, mu_min, k_cem, mu_cem, phi)
     )
 
     # Identify porosity values that exceed (phi_c - frac_cem). This is regardless of setting for extrapolate_to_max_phi
@@ -282,10 +281,7 @@ def constant_cement_model_dry(
         k_dry[idx_phi] = np.nan
         mu[idx_phi] = np.nan
 
-    k_dry, mu = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.filter_output(idx, (k_dry, mu)),
-    )
+    k_dry, mu = gen_utilities.filter_output(idx, (k_dry, mu))
     if return_k_zero:
         return k_zero, k_dry, mu
     return k_dry, mu

--- a/src/rock_physics_open/sandstone_models/constant_cement_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/constant_cement_optimisation.py
@@ -1,4 +1,4 @@
-from typing import Callable, cast
+from typing import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -93,10 +93,7 @@ def constant_cement_model_optimisation(
     # Optimisation function for selected parameters
     opt_fun: Callable[..., npt.NDArray[float64]] = curvefit_constant_cement
     # expand single value parameters to match logs length
-    por, def_vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((por, def_vpvs)),
-    )
+    por, def_vpvs = gen_utilities.dim_check_vector((por, def_vpvs))
     x_data = np.stack(
         (k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, k_fl, rho_fl, por, def_vpvs),
         axis=1,

--- a/src/rock_physics_open/sandstone_models/contact_cement_model.py
+++ b/src/rock_physics_open/sandstone_models/contact_cement_model.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -105,28 +103,24 @@ def contact_cement_model(
             phi,
             _,
         ),
-    ) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log(
-            (
-                k_min,
-                mu_min,
-                rho_min,
-                k_cem,
-                mu_cem,
-                rho_cem,
-                k_fl,
-                rho_fl,
-                phi,
-                phi_c - frac_cem - phi,
-            )
-        ),
+    ) = gen_utilities.filter_input_log(
+        (
+            k_min,
+            mu_min,
+            rho_min,
+            k_cem,
+            mu_cem,
+            rho_cem,
+            k_fl,
+            rho_fl,
+            phi,
+            phi_c - frac_cem - phi,
+        )
     )
 
     # Expand input parameters to arrays
-    phi, frac_cem_, phi_c_, _, _ = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((phi, frac_cem, phi_c, n, shear_red)),
+    phi, frac_cem_, phi_c_, _, _ = gen_utilities.dim_check_vector(
+        (phi, frac_cem, phi_c, n, shear_red)
     )
 
     # At the zero-porosity point, all original porosity (critical porosity) is
@@ -186,9 +180,8 @@ def contact_cement_model(
     vp, vs, ai, vpvs = std_functions.velocity(k=k, mu=mu, rhob=rho)
 
     # Restore original array length
-    vp, vs, rho, ai, vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.filter_output(idx_phi, (vp, vs, rho, ai, vpvs)),
+    vp, vs, rho, ai, vpvs = gen_utilities.filter_output(
+        idx_phi, (vp, vs, rho, ai, vpvs)
     )
 
     return vp, vs, rho, ai, vpvs

--- a/src/rock_physics_open/sandstone_models/friable_models.py
+++ b/src/rock_physics_open/sandstone_models/friable_models.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -188,22 +188,16 @@ def friable_model_dry(
         Shear modulus of dry rock [Pa].
     """
     # Expand floats to arrays, check for equal length
-    phi, phi_c_, shear_red_, k_min, mu_min, p_eff, n_ = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector(
-            (phi, phi_c, shear_red, k_min, mu_min, p_eff, n)
-        ),
+    phi, phi_c_, shear_red_, k_min, mu_min, p_eff, n_ = gen_utilities.dim_check_vector(
+        (phi, phi_c, shear_red, k_min, mu_min, p_eff, n)
     )
     # Valid porosity values are less or equal to the critical porosity
     # Use filter_input_log to remove values that do not comply with this
     (
         idx_phi,
         (phi, phi_c_, shear_red_, k_min, mu_min, p_eff, _),
-    ) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log(
-            (phi, phi_c_, shear_red_, k_min, mu_min, p_eff, phi_c - phi)
-        ),
+    ) = gen_utilities.filter_input_log(
+        (phi, phi_c_, shear_red_, k_min, mu_min, p_eff, phi_c - phi)
     )
 
     # Dry rock properties of high-porosity end member calculated with
@@ -239,8 +233,6 @@ def friable_model_dry(
         k_min, mu_min, k_hm, mu_hm, f1, bound="lower"
     )
 
-    k_dry, mu = cast(
-        list[npt.NDArray[np.float64]], gen_utilities.filter_output(idx_phi, (k_dry, mu))
-    )
+    k_dry, mu = gen_utilities.filter_output(idx_phi, (k_dry, mu))
 
     return k_dry, mu

--- a/src/rock_physics_open/sandstone_models/friable_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/friable_optimisation.py
@@ -1,4 +1,4 @@
-from typing import Callable, cast
+from typing import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -96,10 +96,7 @@ def friable_model_optimisation(
     # Optimisation function for selected parameters
     opt_fun: Callable[..., NDArray[float64]] = curvefit_friable
     # expand single value parameters to match logs length
-    por, def_vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((por, def_vpvs)),
-    )
+    por, def_vpvs = gen_utilities.dim_check_vector((por, def_vpvs))
     x_data = np.stack(
         (k_min, mu_min, rho_min, k_fl, rho_fl, por, p_eff, def_vpvs), axis=1
     )

--- a/src/rock_physics_open/sandstone_models/friable_shalysand_sandyshale_models.py
+++ b/src/rock_physics_open/sandstone_models/friable_shalysand_sandyshale_models.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -138,36 +136,30 @@ def friable_shaly_sand_sandy_shale_model(
             _,
             _,
         ),
-    ) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        gen_utilities.filter_input_log(
-            (
-                k_sst,
-                mu_sst,
-                rho_sst,
-                k_mud,
-                mu_mud,
-                rho_mud,
-                k_fl_sst,
-                rho_fl_sst,
-                k_fl_mud,
-                rho_fl_mud,
-                phi,
-                p_eff_sst,
-                p_eff_mud,
-                shale_frac,
-                phi_c_sst - phi,
-                phi - phi_intr_mud,
-            ),
-            no_zero=False,
+    ) = gen_utilities.filter_input_log(
+        (
+            k_sst,
+            mu_sst,
+            rho_sst,
+            k_mud,
+            mu_mud,
+            rho_mud,
+            k_fl_sst,
+            rho_fl_sst,
+            k_fl_mud,
+            rho_fl_mud,
+            phi,
+            p_eff_sst,
+            p_eff_mud,
+            shale_frac,
+            phi_c_sst - phi,
+            phi - phi_intr_mud,
         ),
+        no_zero=False,
     )
 
     # Expand the needed variables from float to numpy array
-    phi, phi_intr_mud_ = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((phi, phi_intr_mud)),
-    )
+    phi, phi_intr_mud_ = gen_utilities.dim_check_vector((phi, phi_intr_mud))
 
     sandy_shale_idx = shale_frac > phi
     shaly_sand_idx = ~sandy_shale_idx
@@ -264,9 +256,8 @@ def friable_shaly_sand_sandy_shale_model(
     vp, vs, ai, vpvs = std_functions.velocity(k=k, mu=mu, rhob=rho)
 
     # Restore original array length
-    vp, vs, rho, ai, vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.filter_output(idx_phi, (vp, vs, rho, ai, vpvs)),
+    vp, vs, rho, ai, vpvs = gen_utilities.filter_output(
+        idx_phi, (vp, vs, rho, ai, vpvs)
     )
 
     return vp, vs, rho, ai, vpvs

--- a/src/rock_physics_open/sandstone_models/patchy_cement_model.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_model.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -375,13 +373,11 @@ def patchy_cement_model_dry(
     """
     # There are cases which suffer from a lack of consistency check at this stage,
     # add dim_check_vector and filter input/output
-    phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff)),
+    phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff = dim_check_vector(
+        (phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff)
     )
-    (idx, (phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff)) = cast(
-        tuple[npt.NDArray[np.bool_], list[npt.NDArray[np.float64]]],
-        filter_input_log((phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff)),
+    (idx, (phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff)) = (
+        filter_input_log((phi, k_min, mu_min, rho_min, k_cem, mu_cem, rho_cem, p_eff))
     )
 
     k_zero, mu_zero = std_functions.hashin_shtrikman_walpole(
@@ -463,8 +459,6 @@ def patchy_cement_model_dry(
 
     rho_dry = (1 - phi - frac_cem) * rho_min + frac_cem * rho_cem
 
-    k_dry, mu, rho_dry = cast(
-        list[npt.NDArray[np.float64]], filter_output(idx, (k_dry, mu, rho_dry))
-    )
+    k_dry, mu, rho_dry = filter_output(idx, (k_dry, mu, rho_dry))
 
     return k_dry, mu, rho_dry

--- a/src/rock_physics_open/sandstone_models/patchy_cement_optimisation.py
+++ b/src/rock_physics_open/sandstone_models/patchy_cement_optimisation.py
@@ -1,4 +1,4 @@
-from typing import Callable, cast
+from typing import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -103,10 +103,7 @@ def patchy_cement_model_optimisation(
     # Optimisation function for selected parameters
     opt_fun: Callable[..., npt.NDArray[np.float64]] = curvefit_patchy_cement
     # expand single value parameters to match logs length
-    por, phi_c_, def_vpvs = cast(
-        list[npt.NDArray[np.float64]],
-        gen_utilities.dim_check_vector((por, phi_c, def_vpvs)),
-    )
+    por, phi_c_, def_vpvs = gen_utilities.dim_check_vector((por, phi_c, def_vpvs))
     x_data = np.stack(
         (
             k_min,

--- a/src/rock_physics_open/shale_models/multi_sca.py
+++ b/src/rock_physics_open/shale_models/multi_sca.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -66,7 +64,7 @@ def multi_sca(
             "Call function with (k_sc,mu_sc,rhob) = multi_sca((k1,mu1,rho1,asp1,frac1, ...,k_n,mu_n,rho_n,asp_n,frac_n,tol)). Fractions must add up to 1.0"
         )
 
-    args_ = cast(list[npt.NDArray[np.float64]], dim_check_vector(args))
+    args_ = dim_check_vector(args)
 
     # Proceed without the parameter, all other inputs should be arrays
 

--- a/src/rock_physics_open/shale_models/shale4_mineral.py
+++ b/src/rock_physics_open/shale_models/shale4_mineral.py
@@ -1,4 +1,4 @@
-from typing import Literal, assert_never, cast
+from typing import Literal, assert_never
 
 import numpy as np
 import numpy.typing as npt
@@ -166,9 +166,8 @@ def shale_model_4_mineral_dem(
     else:
         assert_never(mod_type)
 
-    k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp)),
+    k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp = dim_check_vector(
+        (k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp)
     )
     k, mu, rhob = dem_model(
         k1=k_mat,

--- a/src/rock_physics_open/shale_models/shale4_mineral_dem_overlay.py
+++ b/src/rock_physics_open/shale_models/shale4_mineral_dem_overlay.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import numpy as np
 import numpy.typing as npt
 
@@ -109,9 +107,8 @@ def shale_4_min_dem_overlay(
     )
     rho_mat = rho1 * f1 + rho2 * f2 + rho3 * f3 + rho4 * f4
 
-    k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector((k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp)),
+    k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp = dim_check_vector(
+        (k_mat, mu_mat, rho_mat, k_fl, rho_fl, phi, asp)
     )
     k, mu, rhob = dem_model(
         k1=k_mat,

--- a/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_exp.py
+++ b/src/rock_physics_open/t_matrix_models/curvefit_t_matrix_exp.py
@@ -1,7 +1,4 @@
-from typing import cast
-
 import numpy as np
-import numpy.typing as npt
 
 from rock_physics_open.equinor_utilities.gen_utilities import dim_check_vector
 from rock_physics_open.equinor_utilities.optimisation_utilities import opt_param_info
@@ -88,19 +85,16 @@ def curvefit_t_matrix_exp(
 
     # Mineral properties
     # Expand elastic properties to vectors of the same length as the x_data inputs
-    k_c_, mu_c_, rho_c_, k_sh_, mu_sh_, rho_sh_, _ = cast(
-        list[npt.NDArray[np.float64]],
-        dim_check_vector(
-            (
-                k_c,
-                mu_c,
-                rho_c,
-                k_sh,
-                mu_sh,
-                rho_sh,
-                phi,
-            )
-        ),
+    k_c_, mu_c_, rho_c_, k_sh_, mu_sh_, rho_sh_, _ = dim_check_vector(
+        (
+            k_c,
+            mu_c,
+            rho_c,
+            k_sh,
+            mu_sh,
+            rho_sh,
+            phi,
+        )
     )
     k_min, mu_min = hashin_shtrikman_average(
         k1=k_sh_,

--- a/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
+++ b/src/rock_physics_open/t_matrix_models/parse_t_matrix_inputs.py
@@ -242,23 +242,20 @@ def parse_t_matrix_inputs(
             visco,
             frac_inc_con,
             frac_inc_ani,
-        ) = cast(  # Casting since dim_check_vector typing is incomplete
-            list[Array1D[np.float64]],
-            gen_utilities.dim_check_vector(
-                (
-                    k_min,
-                    mu_min,
-                    rho_min,
-                    k_fl,
-                    rho_fl,
-                    phi,
-                    perm,
-                    visco,
-                    frac_inc_con,
-                    frac_inc_ani,
-                ),
-                force_type=np.dtype(float),
+        ) = gen_utilities.dim_check_vector(
+            (
+                k_min,
+                mu_min,
+                rho_min,
+                k_fl,
+                rho_fl,
+                phi,
+                perm,
+                visco,
+                frac_inc_con,
+                frac_inc_ani,
             ),
+            force_type=np.dtype(np.float64),
         )
     except ValueError:
         raise ValueError("t-matrix inputs: {}".format(str(sys.exc_info())))
@@ -303,18 +300,13 @@ def parse_t_matrix_inputs(
     alpha_shape = alpha.shape
     # First make sure that alpha and v have the same number of elements
     try:
-        alpha_flat, v_flat = (
-            cast(  # casting since dim_check_vector typing is incomplete
-                list[Array1D[np.float64]],
-                gen_utilities.dim_check_vector((alpha, v), force_type=np.dtype(float)),
-            )
+        alpha, v = gen_utilities.dim_check_vector(
+            (alpha, v), force_type=np.dtype(np.float64)
         )
     except ValueError:
         raise ValueError("t-matrix inputs: {}".format(str(sys.exc_info())))
-    alpha = cast(
-        Array1D[np.float64] | Array2D[np.float64], alpha_flat.reshape(alpha_shape)
-    )
-    v = cast(Array1D[np.float64] | Array2D[np.float64], v_flat.reshape(alpha_shape))
+    alpha = cast(Array1D[np.float64] | Array2D[np.float64], alpha.reshape(alpha_shape))
+    v = cast(Array1D[np.float64] | Array2D[np.float64], v.reshape(alpha_shape))
     # If they are 2D arrays, the first dimension should match log_length
     if alpha.ndim == 2:
         if not (alpha_shape[0] == log_length or alpha_shape[0] == 1):

--- a/src/rock_physics_open/t_matrix_models/t_matrix_C.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_C.py
@@ -1,6 +1,6 @@
 import sys
 from ctypes import c_int
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 from tmatrix import tmatrix_porosity_noscenario
@@ -89,11 +89,8 @@ def t_matrix_porosity_c_alpha_v(
     # alpha and v
 
     # frac_inc_con and frac_inc_ani must be of the same length
-    frac_inc_con_, frac_inc_ani_ = (
-        cast(  # casting since dim_check_vector typing is incomplete
-            list[Array1D[np.float64]],
-            gen_utilities.dim_check_vector((frac_inc_con, frac_inc_ani)),
-        )
+    frac_inc_con_, frac_inc_ani_ = gen_utilities.dim_check_vector(
+        (frac_inc_con, frac_inc_ani)
     )
 
     # test for frac_inc_con and frac_inc_ani being of the same length as the logs
@@ -110,23 +107,20 @@ def t_matrix_porosity_c_alpha_v(
             visco,
             frac_inc_con_,
             frac_inc_ani_,
-        ) = cast(  # casting since dim_check_vector typing is incomplete
-            list[Array1D[np.float64]],
-            gen_utilities.dim_check_vector(
-                (
-                    k_min,
-                    mu_min,
-                    rho_min,
-                    k_fl,
-                    rho_fl,
-                    phi,
-                    perm,
-                    visco,
-                    frac_inc_con_,
-                    frac_inc_ani_,
-                ),
-                force_type=np.dtype("float64"),
+        ) = gen_utilities.dim_check_vector(
+            (
+                k_min,
+                mu_min,
+                rho_min,
+                k_fl,
+                rho_fl,
+                phi,
+                perm,
+                visco,
+                frac_inc_con_,
+                frac_inc_ani_,
             ),
+            force_type=np.dtype(np.float64),
         )
         frac_inc_length = log_length
     else:  # Single float value of frac_inc_con, frac_inc_ani or matching number of inclusions
@@ -139,12 +133,9 @@ def t_matrix_porosity_c_alpha_v(
             phi,
             perm,
             visco,
-        ) = cast(  # casting since dim_check_vector typing is incomplete
-            list[Array1D[np.float64]],
-            gen_utilities.dim_check_vector(
-                (k_min, mu_min, rho_min, k_fl, rho_fl, phi, perm, visco),
-                np.dtype("float64"),
-            ),
+        ) = gen_utilities.dim_check_vector(
+            (k_min, mu_min, rho_min, k_fl, rho_fl, phi, perm, visco),
+            np.dtype("float64"),
         )
         frac_inc_length = frac_inc_ani_.shape[0]
 
@@ -155,9 +146,8 @@ def t_matrix_porosity_c_alpha_v(
 
     # Make sure that alpha and v are of the same shape - more about length of alpha further down
     alpha_shape = alpha.shape
-    alpha, v = cast(  # casting since dim_check_vector typing is incomplete
-        list[Array2D[np.float64]],
-        gen_utilities.dim_check_vector((alpha, v), force_type=np.dtype("float64")),
+    alpha, v = gen_utilities.dim_check_vector(
+        (alpha, v), force_type=np.dtype(np.float64)
     )
     alpha = alpha.reshape(alpha_shape)
     v = v.reshape(alpha_shape)

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_exp.py
@@ -117,9 +117,8 @@ def run_t_matrix_with_opt_params_exp(
     opt_type, opt_params, opt_dict = load_opt_params(f_name)
     y_data = np.stack([vp, vs], axis=1)
     y_shape = y_data.shape
-    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = cast(
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector((phi, angle, perm, visco, tau, freq, 1.0)),
+    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = gen_utilities.dim_check_vector(
+        (phi, angle, perm, visco, tau, freq, 1.0)
     )
 
     rho_sub = rhob + (fl_rho_sub - fl_rho_orig) * phi

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_petec.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_fluid_sub_petec.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import cast
 
 import numpy as np
 
@@ -118,9 +117,8 @@ def run_t_matrix_with_opt_params_petec(
     _, opt_params, _ = load_opt_params(f_name)
     y_data = np.stack([vp, vs], axis=1)
     y_shape = y_data.shape
-    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = cast(
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector((phi, angle, perm, visco, tau, freq, 1.0)),
+    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = gen_utilities.dim_check_vector(
+        (phi, angle, perm, visco, tau, freq, 1.0)
     )
 
     rho_sub = rhob + (fl_rho_sub - fl_rho_orig) * phi

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_exp.py
@@ -86,9 +86,8 @@ def run_t_matrix_forward_model_with_opt_params_exp(
     """
     opt_type, opt_params, opt_dict = load_opt_params(f_name)
     _, scale_val, _ = opt_param_info()
-    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = cast(
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector((phi, angle, perm, visco, tau, freq, 1.0)),
+    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = gen_utilities.dim_check_vector(
+        (phi, angle, perm, visco, tau, freq, 1.0)
     )
 
     if opt_type != "exp":

--- a/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_opt_forward_model_min.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import cast
 
 import numpy as np
 
@@ -87,9 +86,8 @@ def run_t_matrix_forward_model_with_opt_params_petec(
         If forward model fails.
     """
     opt_type, opt_params, _ = load_opt_params(f_name)
-    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = cast(
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector((phi, angle, perm, visco, tau, freq, 1.0)),
+    phi, angle_, perm_, visco_, tau_, freq_, def_vpvs = gen_utilities.dim_check_vector(
+        (phi, angle, perm, visco, tau, freq, 1.0)
     )
     rho_mod = min_rho * (1.0 - phi) + fl_rho * phi
     y_shape = (phi.shape[0], 2)

--- a/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_exp.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_exp.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 
@@ -106,11 +106,8 @@ def t_matrix_optimisation_exp(
     # rho_min = (rhob - por * rho_fl) / (1 - por)
     # EXP adapted inputs: include fluid data and other params in x_data
     # expand single value parameters to match logs length
-    por, angle_, k_r_, eta_f_, tau_, freq_, def_vpvs = cast(
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector(
-            (por, angle, k_r, eta_f, tau, freq, DEF_VP_VS_RATIO)
-        ),
+    por, angle_, k_r_, eta_f_, tau_, freq_, def_vpvs = gen_utilities.dim_check_vector(
+        (por, angle, k_r, eta_f, tau, freq, DEF_VP_VS_RATIO)
     )
     x_data = np.stack(
         (por, vsh, k_fl, rho_fl, angle_, k_r_, eta_f_, tau_, freq_, def_vpvs), axis=1

--- a/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_min.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_parameter_optimisation_min.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 
@@ -121,8 +121,7 @@ def t_matrix_optimisation_petec(
     rhob_mod = rho_min * (1 - por) + rho_fl * por
     rhob_res = rhob - rhob_mod
     # PETEC adapted inputs: include fluid data and other params in x_data
-    por, angle_, k_r_, eta_f_, tau_, freq_, def_vp_vs_ratio = cast(
-        list[Array1D[np.float64]],
+    por, angle_, k_r_, eta_f_, tau_, freq_, def_vp_vs_ratio = (
         gen_utilities.dim_check_vector(
             (
                 por,
@@ -133,7 +132,7 @@ def t_matrix_optimisation_petec(
                 freq,
                 DEF_VP_VS_RATIO,
             )
-        ),
+        )
     )
     x_data = np.stack(
         (

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/t_matrix_vec.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/t_matrix_vec.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypedDict
 
 import numpy as np
 
@@ -122,11 +122,8 @@ def t_matrix_porosity_vectorised(
         phi,
         perm,
         visco,
-    ) = cast(  # casting since dim_check_vector typing is incomplete
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector(
-            (k_min, mu_min, rho_min, k_fl, rho_fl, phi, perm, visco)
-        ),
+    ) = gen_utilities.dim_check_vector(
+        (k_min, mu_min, rho_min, k_fl, rho_fl, phi, perm, visco)
     )
 
     # Conversion to SI units
@@ -134,10 +131,7 @@ def t_matrix_porosity_vectorised(
     visco = visco * 1.0e-2
 
     # Alpha, v and tau should be of the same length
-    (alpha, v, tau) = cast(  # casting since dim_check_vector typing is incomplete
-        list[Array1D[np.float64]],
-        gen_utilities.dim_check_vector((alpha, v, tau)),
-    )
+    (alpha, v, tau) = gen_utilities.dim_check_vector((alpha, v, tau))
     shape_len = alpha.shape[0]
 
     # Shape parameters go into a dict, duplicate here, can be changed with pressure effect

--- a/tests/gen_utilities_tests/test_dim_check_vector.py
+++ b/tests/gen_utilities_tests/test_dim_check_vector.py
@@ -58,9 +58,6 @@ class TestDimCheckVector:
         np.testing.assert_equal(a_out, a_ref)
         np.testing.assert_equal(b_out, b_ref)
         np.testing.assert_equal(c_out, c_ref)
-        if isinstance(a_out, np.ndarray):
-            assert a_out.dtype == a_ref.dtype
-        if isinstance(b_out, np.ndarray):
-            assert b_out.dtype != b_ref.dtype
-        if isinstance(c_out, np.ndarray):
-            assert c_out.dtype != c_ref.dtype
+        assert a_out.dtype == a_ref.dtype
+        assert b_out.dtype != b_ref.dtype
+        assert c_out.dtype != c_ref.dtype


### PR DESCRIPTION
Follow-up to #149. Adds targeted `@overload` signatures to `dim_check_vector`, `filter_input_log`, and `filter_output` in `equinor_utilities/gen_utilities/` so that callers passing tuples/lists of `NDArray[np.float64]` get correctly typed results back. This lets us drop 16+ `cast(list[npt.NDArray[np.float64]], ...)` wrappers spread across sandstone, shale, and T-matrix models.

## Changes

- `gen_utilities/dim_check_vector.py`: add overload for `tuple|list[NDArray[float64] | float | int]` → `list[NDArray[float64]]`; widen fallback return to `list[Any]` so overloads are consistent.
- `gen_utilities/filter_input_log.py`: add float64-specific overload returning `tuple[NDArray[bool_], list[NDArray[float64]]]`.
- `gen_utilities/filter_output.py`: add float64-specific overload returning `list[NDArray[float64]]`.
- Remove ~30 redundant `cast(...)` wrappers across `sandstone_models/*`, `shale_models/*`, `t_matrix_models/*`, `equinor_utilities/*`.
- Small cleanups: hashin_shtrikman cast gone via typed `np.sum(..., dtype=np.float64)`; `display_result_statistics.py` uses `int(np.sign(i))`; removed obsolete `isinstance` branches in `tests/gen_utilities_tests/test_dim_check_vector.py`.

## Validation

- `uv run basedpyright`: 0 errors, 0 warnings
- `uv run pytest`: 186 passed
- `uv run pre-commit run --all-files`: all hooks pass

Based on `refactor/resolve-pyright-ignores` — merge that branch first.