### PR TITLE
ci: improve workflow naming and consistency

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@
 Always run this first after cloning or pulling:
 
 ```sh
-uv sync --locked --all-extras --dev
+uv sync --locked
 ```
 
 This installs the package in editable mode plus all dev dependencies into `.venv/`. The `--locked` flag ensures `uv.lock` is respected exactly — **do not run `uv lock`** unless intentionally updating dependencies.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,10 @@
-name: lint-and-format
-permissions:
-  contents: read
+name: lint
 
 on:
   workflow_call:
-  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:
@@ -13,13 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install uv
+      - name: Set up Python (uv)
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked
 
-      - name: Run pre-commit
+      - name: pre-commit
         run: uv run pre-commit run --all-files

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -7,7 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-format:
-    uses: ./.github/workflows/lint-and-format.yaml
+  lint:
+    uses: ./.github/workflows/lint.yaml
+
   test:
     uses: ./.github/workflows/test.yaml

--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -1,33 +1,34 @@
 name: push to main branch
 
-permissions:
-  contents: read
-
 on:
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
-  lint-and-format:
-    uses: ./.github/workflows/lint-and-format.yaml
+  lint:
+    uses: ./.github/workflows/lint.yaml
 
   test:
     uses: ./.github/workflows/test.yaml
 
   release-please:
-    needs: test
+    name: release-please
+    needs: [ lint, test ]
     permissions:
-      contents: write
       issues: write
+      contents: write
       pull-requests: write
-    uses: ./.github/workflows/release-please.yaml
     secrets: inherit
+    uses: ./.github/workflows/release-please.yaml
 
   build:
-    name: Build for publishing
-    if: ${{ needs.release-please.outputs.release_created }}
+    name: Build Package
     needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,39 +36,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version-file: .python-version
 
       - name: Build
         run: |
           pip install build
           python -m build
 
-      - name: Upload Artifact
+      - name: Upload Package Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: distribution
+          name: rock-physics-open-distribution
           path: dist/
 
   publish:
-    name: Publish to PyPI
+    name: Publish Package to PyPI
     needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/rock-physics-open
     permissions:
-      id-token: write # required for Trusted Publishing to PyPI
+      id-token: write # required for trusted publishing to PyPI
 
     steps:
-      - name: Download Artifact
+      - name: Download Package Artifact
         uses: actions/download-artifact@v8
         with:
-          name: distribution
+          name: rock-physics-open-distribution
           path: dist/
-          merge-multiple: true
 
-      - name: Publish to PyPI
+      - name: Publish Package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,30 +4,26 @@ on:
   workflow_call:
     outputs:
       release_created:
-        description: "If true, a release PR has been merged"
+        description: "If 'true', a release PR was merged and GitHub release was created"
         value: ${{ jobs.release-please.outputs.release_created }}
-  workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate token
-        id: generate-token
+      - name: Create Token
+        id: create-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
-        id: release
+      - name: release-please
+        id: release-please
+        uses: googleapis/release-please-action@v4
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.create-token.outputs.token }}
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      release_created: ${{ steps.release-please.outputs.release_created }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,20 +1,21 @@
 name: test
-permissions:
-  contents: read
 
 on:
   workflow_call:
-  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        module-resolution: ["uv.lock"]
-        include: # to ensure the "most outdated" versions still work
+        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
+        module-resolution: [ "uv.lock" ]
+        # to ensure the "most outdated" versions still work
+        include:
           - os: windows-latest
             python-version: "3.11"
             module-resolution: lowest
@@ -26,23 +27,20 @@ jobs:
             module-resolution: lowest
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}${{ matrix.module-resolution == 'lowest' && ' (lowest deps)' || '' }}
+    name: ${{ matrix.python-version }} - ${{ matrix.os }}${{ matrix.module-resolution == 'lowest' && ' (lowest)' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install uv
+      - name: Set up Python (uv)
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-suffix: ${{ matrix.module-resolution }}
 
-      - name: Show Machine Information
-        run: uvx --from py-cpuinfo cpuinfo
-
       - name: Install dependencies
-        run: uv sync --all-extras --dev ${{ matrix.module-resolution == 'uv.lock' && '--locked' || '--resolution=lowest-direct' }}
+        run: uv sync ${{ matrix.module-resolution == 'uv.lock' && '--locked' || '--resolution=lowest-direct' }}
 
-      - name: Test
+      - name: pytest
         run: uv run pytest


### PR DESCRIPTION
Lots of minor tweaks, primarily to workflow/step naming for consistency and removing some redundancy.

---
Example of before vs after, it seems including `/` in step names makes the github "cut off" parts of the name in the UI.

<img width="49%" alt="Screenshot 2026-04-24 at 10 11 27" src="https://github.com/user-attachments/assets/553aae5b-b576-430f-b8b8-5aba75284272" /><img width="49%" alt="Screenshot 2026-04-24 at 10 10 14" src="https://github.com/user-attachments/assets/e6507723-b8a4-41fb-9c6c-e8b1fc3696e6" />
