### PR TITLE
test: use fixtures instead of importing TESTDATA_DIR

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,8 @@ src/rock_physics_open/      # Main package (editable install)
 └── ternary_plots/          # Ternary diagram utilities
 
 tests/                      # Mirrors src structure with *_tests/ directories
-├── conftest.py             # Session-scoped fixtures (testdata dir, data_dir)
+├── conftest.py             # Loads fixtures from fixtures/
+├── fixtures/               # Global fixture definitions
 ├── data/                   # Test data files (CSV, PKL)
 └── <module>_tests/         # Test directories per module (snapshots stored in __snapshots__/ via syrupy)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,5 @@
-from pathlib import Path
-
 # load and use fixtures from the `fixtures` directory
 pytest_plugins = [
     "tests.fixtures.snapshot",
     "tests.fixtures.testdata",
 ]
-
-TESTDATA_DIR = Path(__file__).parent / "data"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,9 @@
 from pathlib import Path
-from shutil import copytree
-
-import pytest
-
-ROOT_DIR = Path(__file__).parent.resolve()
-TESTDATA_DIR = ROOT_DIR.joinpath("data")
-
-
-@pytest.fixture(scope="session")
-def testdata() -> Path:
-    return TESTDATA_DIR
-
-
-@pytest.fixture(scope="session", autouse=True, name="data_dir")
-def setup_rock_physics_open_test_data(
-    testdata: Path, tmp_path_factory: pytest.TempPathFactory
-) -> Path:
-    start_dir = tmp_path_factory.mktemp("data")
-
-    _ = copytree(testdata, start_dir, dirs_exist_ok=True)
-
-    return start_dir
-
 
 # load and use fixtures from the `fixtures` directory
 pytest_plugins = [
     "tests.fixtures.snapshot",
+    "tests.fixtures.testdata",
 ]
+
+TESTDATA_DIR = Path(__file__).parent / "data"

--- a/tests/fixtures/testdata.py
+++ b/tests/fixtures/testdata.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from shutil import copytree
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def testdata(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    src_testdata_folder = Path(__file__).parent.parent / "data"  # tests/data
+    tmp_testdata_folder = tmp_path_factory.mktemp("testdata")
+    return copytree(src_testdata_folder, tmp_testdata_folder, dirs_exist_ok=True)

--- a/tests/sandstone_model_tests/test_patchy_cement_fluid_sub_model.py
+++ b/tests/sandstone_model_tests/test_patchy_cement_fluid_sub_model.py
@@ -1,5 +1,10 @@
+from dataclasses import dataclass
+from pathlib import Path
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from rock_physics_open.equinor_utilities.units import g_cc_to_kg_m3
@@ -10,67 +15,102 @@ from rock_physics_open.sandstone_models import (
 )
 from rock_physics_open.sandstone_models.friable_models import CoordinateNumberFunction
 
-from ..conftest import TESTDATA_DIR
 
-dataset = pd.read_csv(TESTDATA_DIR / "test_well.csv")
-
-vp_old = dataset["VP"].to_numpy()
-vs_old = dataset["VS"].to_numpy()
-rho_b_old = g_cc_to_kg_m3(dataset["RHOB"].to_numpy())
-phi = dataset["PHIT"].to_numpy()
-idx_high_phi = phi > 0.1
-phi = phi[idx_high_phi]
-vp_old = vp_old[idx_high_phi]
-vs_old = vs_old[idx_high_phi]
-rho_b_old = rho_b_old[idx_high_phi]
-k_min = 136.8e9 * np.ones_like(phi)
-mu_min = 44.0e9 * np.ones_like(phi)
-rho_min = 2650 * np.ones_like(phi)
-k_cem = 36.8e9 * np.ones_like(phi)
-mu_cem = 44.0e9 * np.ones_like(phi)
-rho_cem = 2650 * np.ones_like(phi)
-k_fl_old = 0.8e9 * np.ones_like(phi)
-rho_fl_old = 850 * np.ones_like(phi)
-k_fl_new = 2.7e9 * np.ones_like(phi)
-rho_fl_new = 1005 * np.ones_like(phi)
-p_eff_old = 20.0e6 * np.ones_like(phi)
-p_eff_new = 25.0e6 * np.ones_like(phi)
-p_eff_low = 20.0e6 * np.ones_like(phi)
-frac_cem_up = 0.10
-frac_cem = 0.03
-phi_c = 0.45
-coord_num_func: CoordinateNumberFunction = "PorBased"
-n = 8.0
-shear_red = 0.3
-weight_k = 0.6
-weight_mu = 0.4
+@dataclass(frozen=True)
+class PatchyCementParams:
+    vp_old: npt.NDArray[np.float64]
+    vs_old: npt.NDArray[np.float64]
+    rho_b_old: npt.NDArray[np.float64]
+    phi: npt.NDArray[np.float64]
+    k_min: npt.NDArray[np.float64]
+    mu_min: npt.NDArray[np.float64]
+    rho_min: npt.NDArray[np.float64]
+    k_cem: npt.NDArray[np.float64]
+    mu_cem: npt.NDArray[np.float64]
+    rho_cem: npt.NDArray[np.float64]
+    k_fl_old: npt.NDArray[np.float64]
+    rho_fl_old: npt.NDArray[np.float64]
+    k_fl_new: npt.NDArray[np.float64]
+    rho_fl_new: npt.NDArray[np.float64]
+    p_eff_old: npt.NDArray[np.float64]
+    p_eff_new: npt.NDArray[np.float64]
+    p_eff_low: npt.NDArray[np.float64]
+    frac_cem_up: float
+    frac_cem: float
+    phi_c: float
+    coord_num_func: CoordinateNumberFunction
+    n: float
+    shear_red: float
+    weight_k: float
+    weight_mu: float
 
 
-def test_patchy_cement_fluid_sub_model_no_change(snapshot: SnapshotAssertion):
+@pytest.fixture
+def params(testdata: Path) -> PatchyCementParams:
+    dataset = pd.read_csv(testdata / "test_well.csv")
+
+    vp_old_df = dataset["VP"].to_numpy()
+    vs_old_df = dataset["VS"].to_numpy()
+    rho_b_old_df = dataset["RHOB"].to_numpy()
+    phi_df = dataset["PHIT"].to_numpy()
+    idx_high_phi = phi_df > 0.1
+
+    return PatchyCementParams(
+        vp_old=vp_old_df[idx_high_phi],
+        vs_old=vs_old_df[idx_high_phi],
+        rho_b_old=g_cc_to_kg_m3(rho_b_old_df[idx_high_phi]),
+        phi=phi_df[idx_high_phi],
+        k_min=136.8e9 * np.ones_like(phi_df[idx_high_phi]),
+        mu_min=44.0e9 * np.ones_like(phi_df[idx_high_phi]),
+        rho_min=2650 * np.ones_like(phi_df[idx_high_phi]),
+        k_cem=36.8e9 * np.ones_like(phi_df[idx_high_phi]),
+        mu_cem=44.0e9 * np.ones_like(phi_df[idx_high_phi]),
+        rho_cem=2650 * np.ones_like(phi_df[idx_high_phi]),
+        k_fl_old=0.8e9 * np.ones_like(phi_df[idx_high_phi]),
+        rho_fl_old=850 * np.ones_like(phi_df[idx_high_phi]),
+        k_fl_new=2.7e9 * np.ones_like(phi_df[idx_high_phi]),
+        rho_fl_new=1005 * np.ones_like(phi_df[idx_high_phi]),
+        p_eff_old=20.0e6 * np.ones_like(phi_df[idx_high_phi]),
+        p_eff_new=25.0e6 * np.ones_like(phi_df[idx_high_phi]),
+        p_eff_low=20.0e6 * np.ones_like(phi_df[idx_high_phi]),
+        frac_cem_up=0.10,
+        frac_cem=0.03,
+        phi_c=0.45,
+        coord_num_func="PorBased",
+        n=8.0,
+        shear_red=0.3,
+        weight_k=0.6,
+        weight_mu=0.4,
+    )
+
+
+def test_patchy_cement_fluid_sub_model_no_change(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_pressure_fluid_substitution(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl_old=k_fl_old,
-        rho_fl_old=rho_fl_old,
-        k_fl_new=k_fl_old,
-        rho_fl_new=rho_fl_old,
-        phi=phi,
-        p_eff_old=p_eff_old,
-        p_eff_new=p_eff_old,
-        vp_old=vp_old,
-        vs_old=vs_old,
-        rho_b_old=rho_b_old,
-        p_eff_low=p_eff_low,
-        frac_cem_up=frac_cem_up,
-        frac_cem=frac_cem,
-        shear_red=shear_red,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl_old=params.k_fl_old,
+        rho_fl_old=params.rho_fl_old,
+        k_fl_new=params.k_fl_old,
+        rho_fl_new=params.rho_fl_old,
+        phi=params.phi,
+        p_eff_old=params.p_eff_old,
+        p_eff_new=params.p_eff_old,
+        vp_old=params.vp_old,
+        vs_old=params.vs_old,
+        rho_b_old=params.rho_b_old,
+        p_eff_low=params.p_eff_low,
+        frac_cem_up=params.frac_cem_up,
+        frac_cem=params.frac_cem,
+        shear_red=params.shear_red,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
         model_type="weight",
         phi_below_zero="disregard",
         phi_above_phi_c="disregard",
@@ -80,31 +120,33 @@ def test_patchy_cement_fluid_sub_model_no_change(snapshot: SnapshotAssertion):
     )
 
 
-def test_patchy_cement_fluid_sub_model_weight(snapshot: SnapshotAssertion):
+def test_patchy_cement_fluid_sub_model_weight(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_pressure_fluid_substitution(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl_old=k_fl_old,
-        rho_fl_old=rho_fl_old,
-        k_fl_new=k_fl_new,
-        rho_fl_new=rho_fl_new,
-        phi=phi,
-        p_eff_old=p_eff_old,
-        p_eff_new=p_eff_new,
-        vp_old=vp_old,
-        vs_old=vs_old,
-        rho_b_old=rho_b_old,
-        p_eff_low=p_eff_low,
-        frac_cem_up=frac_cem_up,
-        frac_cem=frac_cem,
-        shear_red=shear_red,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl_old=params.k_fl_old,
+        rho_fl_old=params.rho_fl_old,
+        k_fl_new=params.k_fl_new,
+        rho_fl_new=params.rho_fl_new,
+        phi=params.phi,
+        p_eff_old=params.p_eff_old,
+        p_eff_new=params.p_eff_new,
+        vp_old=params.vp_old,
+        vs_old=params.vs_old,
+        rho_b_old=params.rho_b_old,
+        p_eff_low=params.p_eff_low,
+        frac_cem_up=params.frac_cem_up,
+        frac_cem=params.frac_cem,
+        shear_red=params.shear_red,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
         model_type="weight",
         phi_below_zero="disregard",
         phi_above_phi_c="disregard",
@@ -114,31 +156,33 @@ def test_patchy_cement_fluid_sub_model_weight(snapshot: SnapshotAssertion):
     )
 
 
-def test_patchy_cement_fluid_sub_model_weight_snap(snapshot: SnapshotAssertion):
+def test_patchy_cement_fluid_sub_model_weight_snap(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_pressure_fluid_substitution(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl_old=k_fl_old,
-        rho_fl_old=rho_fl_old,
-        k_fl_new=k_fl_new,
-        rho_fl_new=rho_fl_new,
-        phi=phi,
-        p_eff_old=p_eff_old,
-        p_eff_new=p_eff_new,
-        vp_old=vp_old,
-        vs_old=vs_old,
-        rho_b_old=rho_b_old,
-        p_eff_low=p_eff_low,
-        frac_cem_up=frac_cem_up,
-        frac_cem=frac_cem,
-        shear_red=shear_red,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl_old=params.k_fl_old,
+        rho_fl_old=params.rho_fl_old,
+        k_fl_new=params.k_fl_new,
+        rho_fl_new=params.rho_fl_new,
+        phi=params.phi,
+        p_eff_old=params.p_eff_old,
+        p_eff_new=params.p_eff_new,
+        vp_old=params.vp_old,
+        vs_old=params.vs_old,
+        rho_b_old=params.rho_b_old,
+        p_eff_low=params.p_eff_low,
+        frac_cem_up=params.frac_cem_up,
+        frac_cem=params.frac_cem,
+        shear_red=params.shear_red,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
         model_type="weight",
         phi_below_zero="snap",
         phi_above_phi_c="snap",
@@ -148,31 +192,33 @@ def test_patchy_cement_fluid_sub_model_weight_snap(snapshot: SnapshotAssertion):
     )
 
 
-def test_patchy_cement_fluid_sub_model_cem_frac(snapshot: SnapshotAssertion):
+def test_patchy_cement_fluid_sub_model_cem_frac(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_pressure_fluid_substitution(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl_old=k_fl_old,
-        rho_fl_old=rho_fl_old,
-        k_fl_new=k_fl_new,
-        rho_fl_new=rho_fl_new,
-        phi=phi,
-        p_eff_old=p_eff_old,
-        p_eff_new=p_eff_new,
-        vp_old=vp_old,
-        vs_old=vs_old,
-        rho_b_old=rho_b_old,
-        p_eff_low=p_eff_low,
-        frac_cem_up=frac_cem_up,
-        frac_cem=frac_cem,
-        shear_red=shear_red,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl_old=params.k_fl_old,
+        rho_fl_old=params.rho_fl_old,
+        k_fl_new=params.k_fl_new,
+        rho_fl_new=params.rho_fl_new,
+        phi=params.phi,
+        p_eff_old=params.p_eff_old,
+        p_eff_new=params.p_eff_new,
+        vp_old=params.vp_old,
+        vs_old=params.vs_old,
+        rho_b_old=params.rho_b_old,
+        p_eff_low=params.p_eff_low,
+        frac_cem_up=params.frac_cem_up,
+        frac_cem=params.frac_cem,
+        shear_red=params.shear_red,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
         model_type="cement_fraction",
         phi_below_zero="disregard",
         phi_above_phi_c="disregard",
@@ -182,31 +228,33 @@ def test_patchy_cement_fluid_sub_model_cem_frac(snapshot: SnapshotAssertion):
     )
 
 
-def test_patchy_cement_fluid_sub_model_cem_frac_snap(snapshot: SnapshotAssertion):
+def test_patchy_cement_fluid_sub_model_cem_frac_snap(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_pressure_fluid_substitution(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl_old=k_fl_old,
-        rho_fl_old=rho_fl_old,
-        k_fl_new=k_fl_new,
-        rho_fl_new=rho_fl_new,
-        phi=phi,
-        p_eff_old=p_eff_old,
-        p_eff_new=p_eff_new,
-        vp_old=vp_old,
-        vs_old=vs_old,
-        rho_b_old=rho_b_old,
-        p_eff_low=p_eff_low,
-        frac_cem_up=frac_cem_up,
-        frac_cem=frac_cem,
-        shear_red=shear_red,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl_old=params.k_fl_old,
+        rho_fl_old=params.rho_fl_old,
+        k_fl_new=params.k_fl_new,
+        rho_fl_new=params.rho_fl_new,
+        phi=params.phi,
+        p_eff_old=params.p_eff_old,
+        p_eff_new=params.p_eff_new,
+        vp_old=params.vp_old,
+        vs_old=params.vs_old,
+        rho_b_old=params.rho_b_old,
+        p_eff_low=params.p_eff_low,
+        frac_cem_up=params.frac_cem_up,
+        frac_cem=params.frac_cem,
+        shear_red=params.shear_red,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
         model_type="cement_fraction",
         phi_below_zero="snap",
         phi_above_phi_c="snap",
@@ -216,84 +264,71 @@ def test_patchy_cement_fluid_sub_model_cem_frac_snap(snapshot: SnapshotAssertion
     )
 
 
-def test_patchy_cement_model_weight(snapshot: SnapshotAssertion):
+def test_patchy_cement_model_weight(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_model_weight(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl_old,
-        rho_fl=rho_fl_old,
-        phi=phi,
-        p_eff=p_eff_old,
-        frac_cem=frac_cem,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
-        shear_red=shear_red,
-        weight_k=weight_k,
-        weight_mu=weight_mu,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl=params.k_fl_old,
+        rho_fl=params.rho_fl_old,
+        phi=params.phi,
+        p_eff=params.p_eff_old,
+        frac_cem=params.frac_cem,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
+        shear_red=params.shear_red,
+        weight_k=params.weight_k,
+        weight_mu=params.weight_mu,
     )
 
 
-def test_patchy_cement_model_cem_frac(snapshot: SnapshotAssertion):
+def test_patchy_cement_model_cem_frac(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
     assert snapshot == patchy_cement_model_cem_frac(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl_old,
-        rho_fl=rho_fl_old,
-        phi=phi,
-        p_eff=p_eff_old,
-        frac_cem=frac_cem,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
-        shear_red=shear_red,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl=params.k_fl_old,
+        rho_fl=params.rho_fl_old,
+        phi=params.phi,
+        p_eff=params.p_eff_old,
+        frac_cem=params.frac_cem,
+        phi_c=params.phi_c,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
+        shear_red=params.shear_red,
     )
 
 
-def test_patchy_cement_model_exceed_phi_extrapolate(snapshot: SnapshotAssertion):
-    frac_cem = 0.10
-    phi_c = 0.40
-    assert snapshot == patchy_cement_model_cem_frac(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl_old,
-        rho_fl=rho_fl_old,
-        phi=phi,
-        p_eff=p_eff_old,
-        frac_cem=frac_cem,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
-        shear_red=shear_red,
+def test_patchy_cement_model_exceed_phi_extrapolate(
+    snapshot: SnapshotAssertion, params: PatchyCementParams
+):
+    output = patchy_cement_model_cem_frac(
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl=params.k_fl_old,
+        rho_fl=params.rho_fl_old,
+        phi=params.phi,
+        p_eff=params.p_eff_old,
+        frac_cem=0.10,
+        phi_c=0.40,
+        coord_num_func=params.coord_num_func,
+        n=params.n,
+        shear_red=params.shear_red,
     )
-    # Set flag for extrapolation to True and assert that there are no NaN values in the output
-    args = patchy_cement_model_cem_frac(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl_old,
-        rho_fl=rho_fl_old,
-        phi=phi,
-        p_eff=p_eff_old,
-        frac_cem=frac_cem,
-        phi_c=phi_c,
-        coord_num_func=coord_num_func,
-        n=n,
-        shear_red=shear_red,
-    )
-    assert not np.any(np.isnan(args[0]))
+    assert not np.any(np.isnan(output))
+    assert snapshot == output

--- a/tests/sandstone_model_tests/test_sandstone_optimisation.py
+++ b/tests/sandstone_model_tests/test_sandstone_optimisation.py
@@ -31,8 +31,8 @@ p_eff = 20.0e6 * np.ones_like(phit)
 phi_c = 0.45
 
 
-def test_friable_optimisation(data_dir: Path, snapshot: SnapshotAssertion):
-    file_name = str(data_dir.joinpath("friable_model_optimisation.pkl"))
+def test_friable_optimisation(snapshot: SnapshotAssertion, testdata: Path):
+    file_name = str(testdata / "friable_model_optimisation.pkl")
 
     assert snapshot == friable_model_optimisation(
         k_min=k_min,
@@ -49,8 +49,8 @@ def test_friable_optimisation(data_dir: Path, snapshot: SnapshotAssertion):
     )
 
 
-def test_constant_cement_optimisation(data_dir: Path, snapshot: SnapshotAssertion):
-    file_name = str(data_dir.joinpath("constant_cement_model_optimisation.pkl"))
+def test_constant_cement_optimisation(snapshot: SnapshotAssertion, testdata: Path):
+    file_name = str(testdata / "constant_cement_model_optimisation.pkl")
 
     assert snapshot == constant_cement_model_optimisation(
         k_min=k_min,
@@ -69,8 +69,8 @@ def test_constant_cement_optimisation(data_dir: Path, snapshot: SnapshotAssertio
     )
 
 
-def test_patchy_cement_optimisation(data_dir: Path, snapshot: SnapshotAssertion):
-    file_name = str(data_dir.joinpath("patchy_cement_model_optimisation.pkl"))
+def test_patchy_cement_optimisation(snapshot: SnapshotAssertion, testdata: Path):
+    file_name = str(testdata / "patchy_cement_model_optimisation.pkl")
 
     assert snapshot == patchy_cement_model_optimisation(
         k_min=k_min,

--- a/tests/sandstone_model_tests/test_sandstone_optimisation.py
+++ b/tests/sandstone_model_tests/test_sandstone_optimisation.py
@@ -1,7 +1,10 @@
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from rock_physics_open.sandstone_models import (
@@ -10,82 +13,108 @@ from rock_physics_open.sandstone_models import (
     patchy_cement_model_optimisation,
 )
 
-from ..conftest import TESTDATA_DIR
 
-data_df = pd.read_csv(TESTDATA_DIR / "sandstone_optimisation.csv")
-
-vp = data_df["VP"].to_numpy()
-vs = data_df["VS"].to_numpy()
-rhob = data_df["RHOB"].to_numpy()
-phit = data_df["PHIT"].to_numpy()
-
-k_min = 36.8e9 * np.ones_like(phit)
-mu_min = 44.0e9 * np.ones_like(phit)
-rho_min = 2650 * np.ones_like(phit)
-k_cem = 36.8e9 * np.ones_like(phit)
-mu_cem = 44.0e9 * np.ones_like(phit)
-rho_cem = 2650 * np.ones_like(phit)
-k_fl = 2.7e9 * np.ones_like(phit)
-rho_fl = 1005 * np.ones_like(phit)
-p_eff = 20.0e6 * np.ones_like(phit)
-phi_c = 0.45
+@dataclass(frozen=True)
+class SandstoneOptParams:
+    vp: npt.NDArray[np.float64]
+    vs: npt.NDArray[np.float64]
+    rhob: npt.NDArray[np.float64]
+    phit: npt.NDArray[np.float64]
+    k_min: npt.NDArray[np.float64]
+    mu_min: npt.NDArray[np.float64]
+    rho_min: npt.NDArray[np.float64]
+    k_cem: npt.NDArray[np.float64]
+    mu_cem: npt.NDArray[np.float64]
+    rho_cem: npt.NDArray[np.float64]
+    k_fl: npt.NDArray[np.float64]
+    rho_fl: npt.NDArray[np.float64]
+    p_eff: npt.NDArray[np.float64]
+    phi_c: float
 
 
-def test_friable_optimisation(snapshot: SnapshotAssertion, testdata: Path):
-    file_name = str(testdata / "friable_model_optimisation.pkl")
+@pytest.fixture
+def params(testdata: Path) -> SandstoneOptParams:
+    data_df = pd.read_csv(testdata / "sandstone_optimisation.csv")
+    phit = data_df["PHIT"].to_numpy()
+    return SandstoneOptParams(
+        vp=data_df["VP"].to_numpy(),
+        vs=data_df["VS"].to_numpy(),
+        rhob=data_df["RHOB"].to_numpy(),
+        phit=phit,
+        k_min=36.8e9 * np.ones_like(phit),
+        mu_min=44.0e9 * np.ones_like(phit),
+        rho_min=2650 * np.ones_like(phit),
+        k_cem=36.8e9 * np.ones_like(phit),
+        mu_cem=44.0e9 * np.ones_like(phit),
+        rho_cem=2650 * np.ones_like(phit),
+        k_fl=2.7e9 * np.ones_like(phit),
+        rho_fl=1005 * np.ones_like(phit),
+        p_eff=20.0e6 * np.ones_like(phit),
+        phi_c=0.45,
+    )
 
+
+def test_friable_optimisation(
+    snapshot: SnapshotAssertion,
+    testdata: Path,
+    params: SandstoneOptParams,
+):
     assert snapshot == friable_model_optimisation(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_fl=k_fl,
-        rho_fl=rho_fl,
-        por=phit,
-        p_eff=p_eff,
-        vp=vp,
-        vs=vs,
-        rhob=rhob,
-        file_out_str=file_name,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_fl=params.k_fl,
+        rho_fl=params.rho_fl,
+        por=params.phit,
+        p_eff=params.p_eff,
+        vp=params.vp,
+        vs=params.vs,
+        rhob=params.rhob,
+        file_out_str=str(testdata / "friable_model_optimisation.pkl"),
     )
 
 
-def test_constant_cement_optimisation(snapshot: SnapshotAssertion, testdata: Path):
-    file_name = str(testdata / "constant_cement_model_optimisation.pkl")
-
+def test_constant_cement_optimisation(
+    snapshot: SnapshotAssertion,
+    testdata: Path,
+    params: SandstoneOptParams,
+):
     assert snapshot == constant_cement_model_optimisation(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl,
-        rho_fl=rho_fl,
-        por=phit,
-        vp=vp,
-        vs=vs,
-        rhob=rhob,
-        file_out_str=file_name,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl=params.k_fl,
+        rho_fl=params.rho_fl,
+        por=params.phit,
+        vp=params.vp,
+        vs=params.vs,
+        rhob=params.rhob,
+        file_out_str=str(testdata / "constant_cement_model_optimisation.pkl"),
     )
 
 
-def test_patchy_cement_optimisation(snapshot: SnapshotAssertion, testdata: Path):
-    file_name = str(testdata / "patchy_cement_model_optimisation.pkl")
-
+def test_patchy_cement_optimisation(
+    snapshot: SnapshotAssertion,
+    testdata: Path,
+    params: SandstoneOptParams,
+):
     assert snapshot == patchy_cement_model_optimisation(
-        k_min=k_min,
-        mu_min=mu_min,
-        rho_min=rho_min,
-        k_cem=k_cem,
-        mu_cem=mu_cem,
-        rho_cem=rho_cem,
-        k_fl=k_fl,
-        rho_fl=rho_fl,
-        por=phit,
-        p_eff=p_eff,
-        vp=vp,
-        vs=vs,
-        rhob=rhob,
-        phi_c=phi_c,
-        file_out_str=file_name,
+        k_min=params.k_min,
+        mu_min=params.mu_min,
+        rho_min=params.rho_min,
+        k_cem=params.k_cem,
+        mu_cem=params.mu_cem,
+        rho_cem=params.rho_cem,
+        k_fl=params.k_fl,
+        rho_fl=params.rho_fl,
+        por=params.phit,
+        p_eff=params.p_eff,
+        vp=params.vp,
+        vs=params.vs,
+        rhob=params.rhob,
+        phi_c=params.phi_c,
+        file_out_str=str(testdata / "patchy_cement_model_optimisation.pkl"),
     )

--- a/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
+++ b/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
@@ -8,15 +8,15 @@ from rock_physics_open.equinor_utilities.optimisation_utilities import (
 
 
 def test_opt_param_to_ascii_display_petec(
-    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+    monkeypatch: pytest.MonkeyPatch, testdata: Path
 ):
-    monkeypatch.chdir(data_dir)
-    in_file = data_dir.joinpath("petec_opt_param_test.pkl")
+    monkeypatch.chdir(testdata)
+    in_file = testdata.joinpath("petec_opt_param_test.pkl")
     try:
         opt_param_to_ascii(in_file, display_results=False)
     except (ValueError, IOError):
         raise ValueError(f"Not possible to read input file {in_file}")
-    out_file = data_dir.joinpath("petec_opt_param.txt")
+    out_file = testdata.joinpath("petec_opt_param.txt")
     try:
         opt_param_to_ascii(in_file, display_results=False, out_file=out_file)
     except (ValueError, IOError):
@@ -24,15 +24,15 @@ def test_opt_param_to_ascii_display_petec(
 
 
 def test_opt_param_to_ascii_display_exp(
-    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+    monkeypatch: pytest.MonkeyPatch, testdata: Path
 ):
-    monkeypatch.chdir(data_dir)
-    in_file = data_dir.joinpath("exp_opt_param_test.pkl")
+    monkeypatch.chdir(testdata)
+    in_file = testdata.joinpath("exp_opt_param_test.pkl")
     try:
         opt_param_to_ascii(in_file, display_results=False)
     except (ValueError, IOError):
         raise ValueError(f"Not possible to read input file {in_file}")
-    out_file = data_dir.joinpath("exp_opt_param.txt")
+    out_file = testdata.joinpath("exp_opt_param.txt")
     try:
         opt_param_to_ascii(in_file, display_results=False, out_file=out_file)
     except (ValueError, IOError):

--- a/tests/t_matrix_model_tests/test_run_t_matrix_with_opt_params.py
+++ b/tests/t_matrix_model_tests/test_run_t_matrix_with_opt_params.py
@@ -80,7 +80,8 @@ def test_run_t_matrix_with_opt_params_exp(snapshot: SnapshotAssertion, testdata:
 
 
 def test_run_t_matrix_opt_forward_model_petec(
-    snapshot: SnapshotAssertion, testdata: Path
+    snapshot: SnapshotAssertion,
+    testdata: Path,
 ):
     fname = testdata.joinpath("petec_opt_param.pkl")
     assert snapshot == run_t_matrix_forward_model_with_opt_params_petec(

--- a/tests/t_matrix_model_tests/test_run_t_matrix_with_opt_params.py
+++ b/tests/t_matrix_model_tests/test_run_t_matrix_with_opt_params.py
@@ -31,9 +31,10 @@ pressure = np.array([20.0e6, 22.0e6])
 
 
 def test_run_t_matrix_with_opt_params_petec(
-    data_dir: Path, snapshot: SnapshotAssertion
+    snapshot: SnapshotAssertion,
+    testdata: Path,
 ):
-    fname = data_dir.joinpath("petec_opt_param.pkl")
+    fname = testdata.joinpath("petec_opt_param.pkl")
     assert snapshot == run_t_matrix_with_opt_params_petec(
         min_k=k_min,
         min_mu=mu_min,
@@ -56,8 +57,8 @@ def test_run_t_matrix_with_opt_params_petec(
     )
 
 
-def test_run_t_matrix_with_opt_params_exp(data_dir: Path, snapshot: SnapshotAssertion):
-    fname = data_dir.joinpath("exp_opt_param.pkl")
+def test_run_t_matrix_with_opt_params_exp(snapshot: SnapshotAssertion, testdata: Path):
+    fname = testdata.joinpath("exp_opt_param.pkl")
     assert snapshot == run_t_matrix_with_opt_params_exp(
         fl_k_orig=k_fl_orig,
         fl_rho_orig=rho_fl_orig,
@@ -79,9 +80,9 @@ def test_run_t_matrix_with_opt_params_exp(data_dir: Path, snapshot: SnapshotAsse
 
 
 def test_run_t_matrix_opt_forward_model_petec(
-    data_dir: Path, snapshot: SnapshotAssertion
+    snapshot: SnapshotAssertion, testdata: Path
 ):
-    fname = data_dir.joinpath("petec_opt_param.pkl")
+    fname = testdata.joinpath("petec_opt_param.pkl")
     assert snapshot == run_t_matrix_forward_model_with_opt_params_petec(
         min_k=k_min,
         min_mu=mu_min,
@@ -99,9 +100,9 @@ def test_run_t_matrix_opt_forward_model_petec(
 
 
 def test_run_t_matrix_opt_forward_model_exp(
-    data_dir: Path, snapshot: SnapshotAssertion
+    snapshot: SnapshotAssertion, testdata: Path
 ):
-    fname = data_dir.joinpath("exp_opt_param.pkl")
+    fname = testdata.joinpath("exp_opt_param.pkl")
     assert snapshot == run_t_matrix_forward_model_with_opt_params_exp(
         fl_k=k_fl_orig,
         fl_rho=rho_fl_orig,

--- a/tests/t_matrix_model_tests/test_t_matrix_optimisation.py
+++ b/tests/t_matrix_model_tests/test_t_matrix_optimisation.py
@@ -1,6 +1,10 @@
+from dataclasses import dataclass
+from pathlib import Path
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from rock_physics_open.equinor_utilities.optimisation_utilities import gen_opt_routine
@@ -12,26 +16,49 @@ from rock_physics_open.t_matrix_models.curvefit_t_matrix_min import (
     curve_fit_2_inclusion_sets,
 )
 
-from ..conftest import TESTDATA_DIR
 
-inp_df = pd.read_csv(TESTDATA_DIR / "tmatrix_test_data.csv")
+@dataclass(frozen=True)
+class TMatrixParams:
+    k_min: npt.NDArray[np.float64]
+    mu_min: npt.NDArray[np.float64]
+    rho_min: npt.NDArray[np.float64]
+    k_fl_orig: npt.NDArray[np.float64]
+    rho_fl_orig: npt.NDArray[np.float64]
+    vp: npt.NDArray[np.float64]
+    vs: npt.NDArray[np.float64]
+    rho: npt.NDArray[np.float64]
+    phi: npt.NDArray[np.float64]
+    vsh: npt.NDArray[np.float64]
+    tau: npt.NDArray[np.float64]
+    angle: npt.NDArray[np.float64]
+    perm: npt.NDArray[np.float64]
+    visco: npt.NDArray[np.float64]
+    freq: npt.NDArray[np.float64]
+    def_vp_vs_ratio: npt.NDArray[np.float64]
 
-k_min = inp_df["K_MIN"].to_numpy() * 1.0e9
-mu_min = inp_df["MU_MIN"].to_numpy() * 1.0e9
-rho_min = g_cc_to_kg_m3(inp_df["RHO_MIN"].to_numpy())
-k_fl_orig = inp_df["K_FL"].to_numpy() * 1.0e9
-rho_fl_orig = g_cc_to_kg_m3(inp_df["RHO_FL"].to_numpy())
-vp = inp_df["VP"].to_numpy()
-vs = inp_df["VS"].to_numpy()
-rho = g_cc_to_kg_m3(inp_df["RHOB"].to_numpy())
-phi = inp_df["PHIT"].to_numpy()
-vsh = inp_df["VSH"].to_numpy()
-tau = 1e-7 * np.ones_like(phi)
-angle = 45 * np.ones_like(phi)
-perm = 100.0 * np.ones_like(phi)
-visco = 100.0 * np.ones_like(phi)
-freq = 1000.0 * np.ones_like(phi)
-def_vp_vs_ratio = 1.8 * np.ones_like(phi)
+
+@pytest.fixture
+def params(testdata: Path) -> TMatrixParams:
+    inp_df = pd.read_csv(testdata / "tmatrix_test_data.csv")
+    phi = inp_df["PHIT"].to_numpy()
+    return TMatrixParams(
+        k_min=inp_df["K_MIN"].to_numpy() * 1.0e9,
+        mu_min=inp_df["MU_MIN"].to_numpy() * 1.0e9,
+        rho_min=g_cc_to_kg_m3(inp_df["RHO_MIN"].to_numpy()),
+        k_fl_orig=inp_df["K_FL"].to_numpy() * 1.0e9,
+        rho_fl_orig=g_cc_to_kg_m3(inp_df["RHO_FL"].to_numpy()),
+        vp=inp_df["VP"].to_numpy(),
+        vs=inp_df["VS"].to_numpy(),
+        rho=g_cc_to_kg_m3(inp_df["RHOB"].to_numpy()),
+        phi=phi,
+        vsh=inp_df["VSH"].to_numpy(),
+        tau=1e-7 * np.ones_like(phi),
+        angle=45 * np.ones_like(phi),
+        perm=100.0 * np.ones_like(phi),
+        visco=100.0 * np.ones_like(phi),
+        freq=1000.0 * np.ones_like(phi),
+        def_vp_vs_ratio=1.8 * np.ones_like(phi),
+    )
 
 
 """
@@ -100,21 +127,21 @@ def test_optimisation_part(snapshot_approx: SnapshotAssertion):
     assert snapshot_approx == opt_params
 
 
-def test_t_matrix_opt_params_petec(snapshot: SnapshotAssertion):
+def test_t_matrix_opt_params_petec(snapshot: SnapshotAssertion, params: TMatrixParams):
     x_data = np.stack(
         (
-            phi,
-            k_min,
-            mu_min,
-            rho_min,
-            k_fl_orig,
-            rho_fl_orig,
-            angle,
-            perm,
-            visco,
-            tau,
-            freq,
-            def_vp_vs_ratio,
+            params.phi,
+            params.k_min,
+            params.mu_min,
+            params.rho_min,
+            params.k_fl_orig,
+            params.rho_fl_orig,
+            params.angle,
+            params.perm,
+            params.visco,
+            params.tau,
+            params.freq,
+            params.def_vp_vs_ratio,
         ),
         axis=1,
     )
@@ -123,19 +150,19 @@ def test_t_matrix_opt_params_petec(snapshot: SnapshotAssertion):
     assert snapshot == curve_fit_2_inclusion_sets(x_data, *par)
 
 
-def test_t_matrix_opt_params_exp(snapshot: SnapshotAssertion):
+def test_t_matrix_opt_params_exp(snapshot: SnapshotAssertion, params: TMatrixParams):
     x_data = np.stack(
         (
-            phi,
-            vsh,
-            k_fl_orig,
-            rho_fl_orig,
-            angle,
-            perm,
-            visco,
-            tau,
-            freq,
-            def_vp_vs_ratio,
+            params.phi,
+            params.vsh,
+            params.k_fl_orig,
+            params.rho_fl_orig,
+            params.angle,
+            params.perm,
+            params.visco,
+            params.tau,
+            params.freq,
+            params.def_vp_vs_ratio,
         ),
         axis=1,
     )

--- a/tests/various_utilities_tests/test_vp_vs_rho_stats.py
+++ b/tests/various_utilities_tests/test_vp_vs_rho_stats.py
@@ -6,7 +6,7 @@ from syrupy.assertion import SnapshotAssertion
 from rock_physics_open.equinor_utilities.various_utilities import vp_vs_rho_stats
 
 
-def test_vp_vs_rho_stats(data_dir: Path, snapshot: SnapshotAssertion):
+def test_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
     rng = np.random.default_rng(123456)
     vp_obs = rng.uniform(low=0.0, high=1.0, size=100)
     vs_obs = rng.uniform(low=0.0, high=1.0, size=100)
@@ -14,7 +14,7 @@ def test_vp_vs_rho_stats(data_dir: Path, snapshot: SnapshotAssertion):
     vp_est = rng.uniform(low=0.0, high=1.0, size=100)
     vs_est = rng.uniform(low=0.0, high=1.0, size=100)
     rho_est = rng.uniform(low=0.0, high=1.0, size=100)
-    fname = str(data_dir / "vp_vs_rho_stats.csv")
+    fname = str(testdata / "vp_vs_rho_stats.csv")
     file_open_mode = "w"
     disp_res = False
     vp_vs_rho_stats(
@@ -33,7 +33,7 @@ def test_vp_vs_rho_stats(data_dir: Path, snapshot: SnapshotAssertion):
     assert snapshot == Path(fname).read_text().strip()
 
 
-def test_multi_vp_vs_rho_stats(data_dir: Path, snapshot: SnapshotAssertion):
+def test_multi_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
     rng = np.random.default_rng(123456)
     vp_obs = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
     vs_obs = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
@@ -43,7 +43,7 @@ def test_multi_vp_vs_rho_stats(data_dir: Path, snapshot: SnapshotAssertion):
     rho_est = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
     set_names = ["pytest_1", "pytest_2", "pytest_3"]
     well_names = ["pytest_well_1", "pytest_well_2", "pytest_well_3"]
-    fname = str(data_dir / "multi_vp_vs_rho_stats.csv")
+    fname = str(testdata / "multi_vp_vs_rho_stats.csv")
     file_open_mode = "w"
     disp_res = False
     vp_vs_rho_stats(


### PR DESCRIPTION
tests should ideally not be importing from other tests, or the conftest.py file.

The "best" practice is to use pytest fixtures instead, as these dont require imports, and are better suited for testing than manually importing/handling config.