### PR TITLE
refactor: add flake8-use-pathlib (PTH) ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ lint.select = [
     "PIE",     # Python idioms and style
     "PLR1711", # Redundant Return
     "PT",      # PyTest
+    "PTH",     # Use pathlib
     "Q",       # Quotes
     "RET",     # Return statements
     "RSE",     # Raising exceptions

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/base_pressure_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/base_pressure_model.py
@@ -1,5 +1,6 @@
 import pickle
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Self
 
 import numpy as np
@@ -132,7 +133,7 @@ class BasePressureModel(ABC):
         Dictionary containing all model parameters.
         """
 
-    def save(self, file: str | bytes) -> None:
+    def save(self, file: str | Path) -> None:
         """
         Save model to pickle file.
 
@@ -141,12 +142,12 @@ class BasePressureModel(ABC):
         file
             File path for saving.
         """
-        with open(file, "wb") as f_out:
+        with Path(file).open("wb") as f_out:
             pickle.dump(self.todict(), f_out)
 
     @classmethod
     @abstractmethod
-    def load(cls, file: str | bytes) -> Self:
+    def load(cls, file: str | Path) -> Self:
         """
         Load model from pickle file.
 

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/exponential_model.py
@@ -1,4 +1,5 @@
 import pickle
+from pathlib import Path
 from typing import Any, Self, final
 
 import numpy as np
@@ -117,9 +118,9 @@ class ExponentialPressureModel(BasePressureModel):
 
     @override
     @classmethod
-    def load(cls, file: str | bytes) -> Self:
+    def load(cls, file: str | Path) -> Self:
         """Load exponential model from pickle file."""
-        with open(file, "rb") as f_in:
+        with Path(file).open("rb") as f_in:
             d = pickle.load(f_in)
 
         return cls(

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/import_ml_models.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/import_ml_models.py
@@ -1,4 +1,5 @@
 import warnings
+from pathlib import Path
 from pickle import load
 
 from sklearn.preprocessing import OneHotEncoder, RobustScaler
@@ -51,7 +52,7 @@ def import_model(
     ValueError
         If model type is unknown.
     """
-    with open(model_file_name, "rb") as fin, warnings.catch_warnings():
+    with Path(model_file_name).open("rb") as fin, warnings.catch_warnings():
         # 11.04.2021 HFLE: There is an issue that is not connected to the local function, in that a warning is issued
         # when the model is loaded, claiming that it is of an older version. This is debugged in detail, and the model
         # IS of the correct version, so the error arise elsewhere. To avoid confusion, the warning is suppressed here
@@ -72,7 +73,7 @@ def import_model(
     cat_var: str | list[str] = []
     try:
         if mod_dict["ohe"]:
-            with open(mod_dict["ohe"], "rb") as f:
+            with Path(mod_dict["ohe"]).open("rb") as f:
                 ohe_dict = load(f)
                 ohe = ohe_dict["ohe"]
                 cat_var = ohe_dict["cat_var"]

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/polynomial_model.py
@@ -1,4 +1,5 @@
 import pickle
+from pathlib import Path
 from typing import Any, Self, final
 
 import numpy as np
@@ -118,9 +119,9 @@ class PolynomialPressureModel(BasePressureModel):
 
     @override
     @classmethod
-    def load(cls, file: str | bytes) -> Self:
+    def load(cls, file: str | Path) -> Self:
         """Load polynomial model from pickle file."""
-        with open(file, "rb") as f_in:
+        with Path(file).open("rb") as f_in:
             d = pickle.load(f_in)
 
         return cls(

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/run_regression.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/run_regression.py
@@ -27,7 +27,7 @@ def _read_models(
     list[str],
 ]:
     # Find the directory of the model files, change working directory, return to original directory at end of function
-    orig_dir = os.getcwd()
+    orig_dir = Path.cwd()
     if model_dir is None:
         model_dir, _ = os.path.split(model_files[0])
     os.chdir(model_dir)

--- a/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
+++ b/src/rock_physics_open/equinor_utilities/machine_learning_utilities/sigmoidal_model.py
@@ -1,4 +1,5 @@
 import pickle
+from pathlib import Path
 from typing import Any, Self, final
 
 import numpy as np
@@ -214,9 +215,9 @@ class SigmoidalPressureModel(BasePressureModel):
 
     @override
     @classmethod
-    def load(cls, file: str | bytes) -> Self:
+    def load(cls, file: str | Path) -> Self:
         """Load sigmoidal model from pickle file."""
-        with open(file, "rb") as f_in:
+        with Path(file).open("rb") as f_in:
             d = pickle.load(f_in)
 
         return cls(

--- a/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
+++ b/src/rock_physics_open/equinor_utilities/optimisation_utilities/opt_subst_utilities.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 import sys
 from pathlib import Path
@@ -321,7 +320,7 @@ def save_opt_params(
     else:
         assert_never(opt_type)
 
-    with open(file_name, "wb") as file_out:
+    with Path(file_name).open("wb") as file_out:
         pickle.dump(opt_param_dict, file_out)
 
 
@@ -407,7 +406,7 @@ def load_opt_params(
     opt_dict
         Full dictionary of optimisation results as loaded from the file.
     """
-    with open(file_name, "rb") as fin:
+    with Path(file_name).open("rb") as fin:
         param_dict: OptParamsDict = pickle.load(fin)
         opt_type = param_dict["opt_ver"]
         opt_param = param_dict["opt_vec"]
@@ -438,7 +437,7 @@ def opt_param_to_ascii(
     **kwargs
         Keyword arguments for tkinter.
     """
-    with open(in_file, "rb") as f_in:
+    with Path(in_file).open("rb") as f_in:
         param_dict = pickle.load(f_in)
         if well_name.lower() == "unknown well":
             well_name = param_dict.pop("well_name", "Unknown Well")
@@ -506,10 +505,10 @@ def opt_param_to_ascii(
             else:
                 root.title(well_name)
             if sys.platform.startswith("win"):
-                ico_file = os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)),
-                    "various_utilities",
-                    "Equinor_logo.ico",
+                ico_file = (
+                    Path(__file__).parent.parent
+                    / "various_utilities"
+                    / "Equinor_logo.ico"
                 )
                 root.iconbitmap(ico_file)
             _ = Table(root, info_array.shape[0], info_array.shape[1], info_array)
@@ -517,7 +516,7 @@ def opt_param_to_ascii(
             root.mainloop()
 
         if out_file is not None:
-            with open(out_file, "w") as f_out:
+            with Path(out_file).open("w") as f_out:
                 _ = f_out.write(disp_string)
 
         return

--- a/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/display_result_statistics.py
@@ -1,6 +1,6 @@
-import os
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
@@ -86,11 +86,9 @@ def disp_result_stats(
     )
 
     if sys.platform.startswith("win"):
-        root.iconbitmap(os.path.join(os.path.dirname(__file__), "Equinor_logo.ico"))
+        root.iconbitmap(Path(__file__).parent / "Equinor_logo.ico")
     else:
-        logo = PhotoImage(
-            file=os.path.join(os.path.dirname(__file__), "Equinor_logo.gif")
-        )
+        logo = PhotoImage(file=Path(__file__).parent / "Equinor_logo.gif")
         root.wm_iconphoto(True, logo)
 
     root.mainloop()

--- a/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
+++ b/src/rock_physics_open/equinor_utilities/various_utilities/vp_vs_rho_set_statistics.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import Literal, cast
 
 import numpy as np
@@ -127,7 +127,7 @@ def vp_vs_rho_stats(
             )
     # Test if the file already exists. If so, and the file_mode is set to 'a', drop the column headers when writing
     # the file
-    if os.path.exists(fname) and file_mode == "a":
+    if Path(fname).exists() and file_mode == "a":
         est_frame.to_csv(fname, mode=file_mode, header=False)
     else:
         est_frame.to_csv(fname, mode=file_mode)

--- a/tests/machine_learning_utilities_test/test_pressure_models.py
+++ b/tests/machine_learning_utilities_test/test_pressure_models.py
@@ -10,8 +10,8 @@ pytest test_pressure_models.py -m benchmark         # Run only benchmarks
 pytest test_pressure_models.py -k "exponential"     # Run tests matching pattern
 """
 
-import os
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -188,7 +188,7 @@ class TestExponentialPressureModel:
             assert loaded_model.b_factor == exponential_model.b_factor
             assert loaded_model.max_pressure == exponential_model.max_pressure
         finally:
-            os.unlink(tmp_path)
+            Path(tmp_path).unlink()
 
 
 # Test PolynomialPressureModel
@@ -313,7 +313,7 @@ class TestModelIntegration:
                 assert original_dict == loaded_dict
 
             finally:
-                os.unlink(tmp_path)
+                Path(tmp_path).unlink()
 
 
 # Performance Tests


### PR DESCRIPTION
Closes #157

Enables ruff's `flake8-use-pathlib` (`PTH`) ruleset and replaces remaining `os.path`, `os.getcwd`, `os.unlink`, and builtin `open()` calls with `pathlib` equivalents.

### Changes
- Added `PTH` to `lint.select` in `pyproject.toml`.
- Replaced `open(path, ...)` with `Path(path).open(...)` in ML model save/load and optimisation utilities.
- Replaced `os.path.join(os.path.dirname(__file__), ...)` with `Path(__file__).parent / ...`.
- Replaced `os.getcwd()` with `Path.cwd()` and `os.path.exists()` with `Path(...).exists()`.
- Replaced `os.unlink` with `Path(...).unlink()` in tests.
- Narrowed `file: str | bytes` → `file: str | Path` on pressure-model `save`/`load` signatures (`pathlib.Path` does not accept `bytes`).

### Validation
- `uv run pre-commit run --all-files` → all hooks pass
- `uv run pytest` → 187 passed