### PR TITLE
ci: resolve missing permission GHAS alert

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,6 +7,11 @@ on:
         description: "If 'true', a release PR was merged and GitHub release was created"
         value: ${{ jobs.release-please.outputs.release_created }}
 
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
my oopsie, 
as i thought it would understand that it gets it permissions from the `on-push-main` workflow.

resolves https://github.com/equinor/rock-physics-open/security/code-scanning/10