### PR TITLE
test: increase test consistency by removing all test classes

### DIFF
--- a/tests/classification_functions_tests/test_class_stats.py
+++ b/tests/classification_functions_tests/test_class_stats.py
@@ -4,38 +4,37 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.classification_functions import gen_class_stats
 
 
-class TestClassStats:
-    def test_class_stats(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((100, 2))
-        inp_id = rg.integers(1, 4, 100)
-        class_mean, class_cov, prior_prob, class_counts, class_id = gen_class_stats(
-            obs, inp_id
-        )
-        class_mean_ref = np.array(
+def test_class_stats():
+    rg = default_rng(234769238476)
+    obs = rg.random((100, 2))
+    inp_id = rg.integers(1, 4, 100)
+    class_mean, class_cov, prior_prob, class_counts, class_id = gen_class_stats(
+        obs, inp_id
+    )
+    class_mean_ref = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_cov_ref = np.array(
+        [
             [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_cov_ref = np.array(
+                [0.06409206, 0.0695167, 0.09727411],
+                [0.00732941, -0.01057039, 0.00734017],
+            ],
             [
-                [
-                    [0.06409206, 0.0695167, 0.09727411],
-                    [0.00732941, -0.01057039, 0.00734017],
-                ],
-                [
-                    [0.00732941, -0.01057039, 0.00734017],
-                    [0.07791386, 0.08905777, 0.07493538],
-                ],
-            ]
-        )
-        prior_prob_ref = np.array([0.28, 0.35, 0.37])
-        class_count_ref = np.array([28, 35, 37])
-        class_id_ref = np.array([1, 2, 3])
-        np.testing.assert_almost_equal(class_mean, class_mean_ref)
-        np.testing.assert_almost_equal(class_cov, class_cov_ref)
-        np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
-        np.testing.assert_equal(class_counts, class_count_ref)
-        np.testing.assert_equal(class_id, class_id_ref)
+                [0.00732941, -0.01057039, 0.00734017],
+                [0.07791386, 0.08905777, 0.07493538],
+            ],
+        ]
+    )
+    prior_prob_ref = np.array([0.28, 0.35, 0.37])
+    class_count_ref = np.array([28, 35, 37])
+    class_id_ref = np.array([1, 2, 3])
+    np.testing.assert_almost_equal(class_mean, class_mean_ref)
+    np.testing.assert_almost_equal(class_cov, class_cov_ref)
+    np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
+    np.testing.assert_equal(class_counts, class_count_ref)
+    np.testing.assert_equal(class_id, class_id_ref)

--- a/tests/classification_functions_tests/test_lin_class.py
+++ b/tests/classification_functions_tests/test_lin_class.py
@@ -4,34 +4,33 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.classification_functions import lin_class
 
 
-class TestLinClass:
-    def test_lin_class(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_mean = np.array(
-            [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_id = np.array([1, 2, 3])
-        lin_class_arr, lin_dist = lin_class(obs, class_mean, class_id)
-        lin_class_ref = np.array([1, 3, 1, 2, 3, 1, 3, 3, 1, 3, 1])
-        lin_dist_ref = np.array(
-            [
-                0.4926242,
-                0.2636271,
-                0.2291065,
-                0.4904759,
-                0.0985496,
-                0.4212475,
-                0.3646983,
-                0.1860129,
-                0.2648174,
-                0.0640302,
-                0.3429182,
-            ]
-        )
-        np.testing.assert_almost_equal(lin_class_arr, lin_class_ref)
-        np.testing.assert_almost_equal(lin_dist, lin_dist_ref)
+def test_lin_class():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_mean = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_id = np.array([1, 2, 3])
+    lin_class_arr, lin_dist = lin_class(obs, class_mean, class_id)
+    lin_class_ref = np.array([1, 3, 1, 2, 3, 1, 3, 3, 1, 3, 1])
+    lin_dist_ref = np.array(
+        [
+            0.4926242,
+            0.2636271,
+            0.2291065,
+            0.4904759,
+            0.0985496,
+            0.4212475,
+            0.3646983,
+            0.1860129,
+            0.2648174,
+            0.0640302,
+            0.3429182,
+        ]
+    )
+    np.testing.assert_almost_equal(lin_class_arr, lin_class_ref)
+    np.testing.assert_almost_equal(lin_dist, lin_dist_ref)

--- a/tests/classification_functions_tests/test_mahal_class.py
+++ b/tests/classification_functions_tests/test_mahal_class.py
@@ -4,125 +4,125 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.classification_functions import mahal_class
 
 
-class TestMahalClass:
-    def test_mahal_class(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_mean = np.array(
+def test_mahal_class():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_mean = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_cov = np.array(
+        [
             [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_cov = np.array(
+                [0.06409206, 0.0695167, 0.09727411],
+                [0.00732941, -0.01057039, 0.00734017],
+            ],
             [
-                [
-                    [0.06409206, 0.0695167, 0.09727411],
-                    [0.00732941, -0.01057039, 0.00734017],
-                ],
-                [
-                    [0.00732941, -0.01057039, 0.00734017],
-                    [0.07791386, 0.08905777, 0.07493538],
-                ],
-            ]
-        )
-        class_id = np.array([1, 2, 3])
-        mahal_class_arr, mahal_dist, mahal_pp = mahal_class(
-            obs, class_mean, class_cov, class_id
-        )
-        mahal_class_ref = np.array([3, 3, 1, 2, 3, 1, 3, 3, 2, 3, 1])
-        mahal_dist_ref = np.array(
-            [
-                1.7566752,
-                0.9532443,
-                0.8388402,
-                1.6136804,
-                0.3358948,
-                1.5194717,
-                1.2497144,
-                0.6221147,
-                1.0361249,
-                0.2204843,
-                1.2178069,
-            ]
-        )
-        mahal_pp_ref = np.array(
-            [
-                0.3657373,
-                0.3392176,
-                0.3635076,
-                0.3976099,
-                0.3662607,
-                0.3604428,
-                0.3710431,
-                0.3795974,
-                0.3387392,
-                0.3620651,
-                0.3627325,
-            ]
-        )
-        np.testing.assert_almost_equal(mahal_class_arr, mahal_class_ref)
-        np.testing.assert_almost_equal(mahal_dist, mahal_dist_ref)
-        np.testing.assert_almost_equal(mahal_pp, mahal_pp_ref)
+                [0.00732941, -0.01057039, 0.00734017],
+                [0.07791386, 0.08905777, 0.07493538],
+            ],
+        ]
+    )
+    class_id = np.array([1, 2, 3])
+    mahal_class_arr, mahal_dist, mahal_pp = mahal_class(
+        obs, class_mean, class_cov, class_id
+    )
+    mahal_class_ref = np.array([3, 3, 1, 2, 3, 1, 3, 3, 2, 3, 1])
+    mahal_dist_ref = np.array(
+        [
+            1.7566752,
+            0.9532443,
+            0.8388402,
+            1.6136804,
+            0.3358948,
+            1.5194717,
+            1.2497144,
+            0.6221147,
+            1.0361249,
+            0.2204843,
+            1.2178069,
+        ]
+    )
+    mahal_pp_ref = np.array(
+        [
+            0.3657373,
+            0.3392176,
+            0.3635076,
+            0.3976099,
+            0.3662607,
+            0.3604428,
+            0.3710431,
+            0.3795974,
+            0.3387392,
+            0.3620651,
+            0.3627325,
+        ]
+    )
+    np.testing.assert_almost_equal(mahal_class_arr, mahal_class_ref)
+    np.testing.assert_almost_equal(mahal_dist, mahal_dist_ref)
+    np.testing.assert_almost_equal(mahal_pp, mahal_pp_ref)
 
-    def test_mahal_class_thresh(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_mean = np.array(
+
+def test_mahal_class_thresh():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_mean = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_cov = np.array(
+        [
             [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_cov = np.array(
+                [0.06409206, 0.0695167, 0.09727411],
+                [0.00732941, -0.01057039, 0.00734017],
+            ],
             [
-                [
-                    [0.06409206, 0.0695167, 0.09727411],
-                    [0.00732941, -0.01057039, 0.00734017],
-                ],
-                [
-                    [0.00732941, -0.01057039, 0.00734017],
-                    [0.07791386, 0.08905777, 0.07493538],
-                ],
-            ]
-        )
-        class_id = np.array([1, 2, 3])
-        mahal_class_arr, mahal_dist, mahal_pp = mahal_class(
-            obs, class_mean, class_cov, class_id, thresh=1.5
-        )
-        mahal_class_ref = np.array([0, 3, 1, 0, 3, 0, 3, 3, 2, 3, 1])
-        mahal_dist_ref = np.array(
-            [
-                1.7566752,
-                0.9532443,
-                0.8388402,
-                1.6136804,
-                0.3358948,
-                1.5194717,
-                1.2497144,
-                0.6221147,
-                1.0361249,
-                0.2204843,
-                1.2178069,
-            ]
-        )
-        mahal_pp_ref = np.array(
-            [
-                0.3657373,
-                0.3392176,
-                0.3635076,
-                0.3976099,
-                0.3662607,
-                0.3604428,
-                0.3710431,
-                0.3795974,
-                0.3387392,
-                0.3620651,
-                0.3627325,
-            ]
-        )
-        np.testing.assert_almost_equal(mahal_class_arr, mahal_class_ref)
-        np.testing.assert_almost_equal(mahal_dist, mahal_dist_ref)
-        np.testing.assert_almost_equal(mahal_pp, mahal_pp_ref)
+                [0.00732941, -0.01057039, 0.00734017],
+                [0.07791386, 0.08905777, 0.07493538],
+            ],
+        ]
+    )
+    class_id = np.array([1, 2, 3])
+    mahal_class_arr, mahal_dist, mahal_pp = mahal_class(
+        obs, class_mean, class_cov, class_id, thresh=1.5
+    )
+    mahal_class_ref = np.array([0, 3, 1, 0, 3, 0, 3, 3, 2, 3, 1])
+    mahal_dist_ref = np.array(
+        [
+            1.7566752,
+            0.9532443,
+            0.8388402,
+            1.6136804,
+            0.3358948,
+            1.5194717,
+            1.2497144,
+            0.6221147,
+            1.0361249,
+            0.2204843,
+            1.2178069,
+        ]
+    )
+    mahal_pp_ref = np.array(
+        [
+            0.3657373,
+            0.3392176,
+            0.3635076,
+            0.3976099,
+            0.3662607,
+            0.3604428,
+            0.3710431,
+            0.3795974,
+            0.3387392,
+            0.3620651,
+            0.3627325,
+        ]
+    )
+    np.testing.assert_almost_equal(mahal_class_arr, mahal_class_ref)
+    np.testing.assert_almost_equal(mahal_dist, mahal_dist_ref)
+    np.testing.assert_almost_equal(mahal_pp, mahal_pp_ref)

--- a/tests/classification_functions_tests/test_norm_class.py
+++ b/tests/classification_functions_tests/test_norm_class.py
@@ -4,127 +4,127 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.classification_functions import norm_class
 
 
-class TestNormClass:
-    def test_norm_class(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_mean = np.array(
+def test_norm_class():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_mean = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_cov = np.array(
+        [
             [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_cov = np.array(
+                [0.06409206, 0.0695167, 0.09727411],
+                [0.00732941, -0.01057039, 0.00734017],
+            ],
             [
-                [
-                    [0.06409206, 0.0695167, 0.09727411],
-                    [0.00732941, -0.01057039, 0.00734017],
-                ],
-                [
-                    [0.00732941, -0.01057039, 0.00734017],
-                    [0.07791386, 0.08905777, 0.07493538],
-                ],
-            ]
-        )
-        prior_prob = np.array([0.28, 0.35, 0.37])
-        class_id = np.array([1, 2, 3])
-        norm_class_arr, norm_dist, norm_pp = norm_class(
-            obs, class_mean, class_cov, prior_prob, class_id
-        )
-        norm_class_ref = np.array([3, 2, 3, 2, 2, 3, 3, 3, 2, 2, 3])
-        norm_dist_ref = np.array(
-            [
-                0.5917953,
-                1.0196095,
-                1.0218156,
-                0.6947731,
-                1.3181127,
-                0.709255,
-                0.8452758,
-                1.1590756,
-                0.9835508,
-                1.3819751,
-                0.8343481,
-            ]
-        )
-        norm_pp_ref = np.array(
-            [
-                -0.356827,
-                -0.3511402,
-                -0.3451817,
-                -0.3821536,
-                -0.3609478,
-                -0.3536818,
-                -0.3579545,
-                -0.3618086,
-                -0.3529041,
-                -0.361059,
-                -0.345492,
-            ]
-        )
-        np.testing.assert_almost_equal(norm_class_arr, norm_class_ref)
-        np.testing.assert_almost_equal(norm_dist, norm_dist_ref)
-        np.testing.assert_almost_equal(norm_pp, norm_pp_ref)
+                [0.00732941, -0.01057039, 0.00734017],
+                [0.07791386, 0.08905777, 0.07493538],
+            ],
+        ]
+    )
+    prior_prob = np.array([0.28, 0.35, 0.37])
+    class_id = np.array([1, 2, 3])
+    norm_class_arr, norm_dist, norm_pp = norm_class(
+        obs, class_mean, class_cov, prior_prob, class_id
+    )
+    norm_class_ref = np.array([3, 2, 3, 2, 2, 3, 3, 3, 2, 2, 3])
+    norm_dist_ref = np.array(
+        [
+            0.5917953,
+            1.0196095,
+            1.0218156,
+            0.6947731,
+            1.3181127,
+            0.709255,
+            0.8452758,
+            1.1590756,
+            0.9835508,
+            1.3819751,
+            0.8343481,
+        ]
+    )
+    norm_pp_ref = np.array(
+        [
+            -0.356827,
+            -0.3511402,
+            -0.3451817,
+            -0.3821536,
+            -0.3609478,
+            -0.3536818,
+            -0.3579545,
+            -0.3618086,
+            -0.3529041,
+            -0.361059,
+            -0.345492,
+        ]
+    )
+    np.testing.assert_almost_equal(norm_class_arr, norm_class_ref)
+    np.testing.assert_almost_equal(norm_dist, norm_dist_ref)
+    np.testing.assert_almost_equal(norm_pp, norm_pp_ref)
 
-    def test_norm_class_thresh(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_mean = np.array(
+
+def test_norm_class_thresh():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_mean = np.array(
+        [
+            [0.4450828, 0.5032985],
+            [0.4959657, 0.4961214],
+            [0.5020109, 0.5090125],
+        ]
+    )
+    class_cov = np.array(
+        [
             [
-                [0.4450828, 0.5032985],
-                [0.4959657, 0.4961214],
-                [0.5020109, 0.5090125],
-            ]
-        )
-        class_cov = np.array(
+                [0.06409206, 0.0695167, 0.09727411],
+                [0.00732941, -0.01057039, 0.00734017],
+            ],
             [
-                [
-                    [0.06409206, 0.0695167, 0.09727411],
-                    [0.00732941, -0.01057039, 0.00734017],
-                ],
-                [
-                    [0.00732941, -0.01057039, 0.00734017],
-                    [0.07791386, 0.08905777, 0.07493538],
-                ],
-            ]
-        )
-        prior_prob = np.array([0.28, 0.35, 0.37])
-        class_id = np.array([1, 2, 3])
-        norm_class_arr, norm_dist, norm_pp = norm_class(
-            obs, class_mean, class_cov, prior_prob, class_id, thresh=1.2
-        )
-        norm_class_ref = np.array([3, 2, 3, 2, 0, 3, 3, 3, 2, 0, 3])
-        norm_dist_ref = np.array(
-            [
-                0.5917953,
-                1.0196095,
-                1.0218156,
-                0.6947731,
-                1.3181127,
-                0.709255,
-                0.8452758,
-                1.1590756,
-                0.9835508,
-                1.3819751,
-                0.8343481,
-            ]
-        )
-        norm_pp_ref = np.array(
-            [
-                -0.356827,
-                -0.3511402,
-                -0.3451817,
-                -0.3821536,
-                -0.3609478,
-                -0.3536818,
-                -0.3579545,
-                -0.3618086,
-                -0.3529041,
-                -0.361059,
-                -0.345492,
-            ]
-        )
-        np.testing.assert_equal(norm_class_arr, norm_class_ref)
-        np.testing.assert_almost_equal(norm_dist, norm_dist_ref)
-        np.testing.assert_almost_equal(norm_pp, norm_pp_ref)
+                [0.00732941, -0.01057039, 0.00734017],
+                [0.07791386, 0.08905777, 0.07493538],
+            ],
+        ]
+    )
+    prior_prob = np.array([0.28, 0.35, 0.37])
+    class_id = np.array([1, 2, 3])
+    norm_class_arr, norm_dist, norm_pp = norm_class(
+        obs, class_mean, class_cov, prior_prob, class_id, thresh=1.2
+    )
+    norm_class_ref = np.array([3, 2, 3, 2, 0, 3, 3, 3, 2, 0, 3])
+    norm_dist_ref = np.array(
+        [
+            0.5917953,
+            1.0196095,
+            1.0218156,
+            0.6947731,
+            1.3181127,
+            0.709255,
+            0.8452758,
+            1.1590756,
+            0.9835508,
+            1.3819751,
+            0.8343481,
+        ]
+    )
+    norm_pp_ref = np.array(
+        [
+            -0.356827,
+            -0.3511402,
+            -0.3451817,
+            -0.3821536,
+            -0.3609478,
+            -0.3536818,
+            -0.3579545,
+            -0.3618086,
+            -0.3529041,
+            -0.361059,
+            -0.345492,
+        ]
+    )
+    np.testing.assert_equal(norm_class_arr, norm_class_ref)
+    np.testing.assert_almost_equal(norm_dist, norm_dist_ref)
+    np.testing.assert_almost_equal(norm_pp, norm_pp_ref)

--- a/tests/classification_functions_tests/test_poly_class.py
+++ b/tests/classification_functions_tests/test_poly_class.py
@@ -4,36 +4,35 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.classification_functions import poly_class
 
 
-class TestPolyClass:
-    def test_poly_class(self):
-        rg = default_rng(234769238476)
-        obs = rg.random((11, 2))
-        class_poly = np.array(
+def test_poly_class():
+    rg = default_rng(234769238476)
+    obs = rg.random((11, 2))
+    class_poly = np.array(
+        [
             [
-                [
-                    [0.0, 0.0],
-                    [0.5, 0.0],
-                    [0.5, 0.5],
-                    [0.0, 0.5],
-                    [0.0, 0.0],
-                ],
-                [
-                    [0.5, 0.0],
-                    [1.0, 0.0],
-                    [1.0, 0.5],
-                    [0.5, 0.5],
-                    [0.5, 0.0],
-                ],
-                [
-                    [0.0, 0.5],
-                    [1.0, 0.5],
-                    [1.0, 1.0],
-                    [0.0, 0.5],
-                    [0.0, 0.0],
-                ],
-            ]
-        )
-        class_id = np.array([1, 2, 3])
-        poly_class_arr = poly_class(obs, class_poly, class_id)
-        poly_class_ref = np.array([1, 3, 1, 2, 2, 1, 3, 2, 0, 2, 1])
-        np.testing.assert_equal(poly_class_arr, poly_class_ref)
+                [0.0, 0.0],
+                [0.5, 0.0],
+                [0.5, 0.5],
+                [0.0, 0.5],
+                [0.0, 0.0],
+            ],
+            [
+                [0.5, 0.0],
+                [1.0, 0.0],
+                [1.0, 0.5],
+                [0.5, 0.5],
+                [0.5, 0.0],
+            ],
+            [
+                [0.0, 0.5],
+                [1.0, 0.5],
+                [1.0, 1.0],
+                [0.0, 0.5],
+                [0.0, 0.0],
+            ],
+        ]
+    )
+    class_id = np.array([1, 2, 3])
+    poly_class_arr = poly_class(obs, class_poly, class_id)
+    poly_class_ref = np.array([1, 3, 1, 2, 2, 1, 3, 2, 0, 2, 1])
+    np.testing.assert_equal(poly_class_arr, poly_class_ref)

--- a/tests/classification_functions_tests/test_two_step_class.py
+++ b/tests/classification_functions_tests/test_two_step_class.py
@@ -6,45 +6,44 @@ from rock_physics_open.equinor_utilities.classification_functions import (
 )
 
 
-class TestTwoStepClass:
-    def test_mahal_class_thresh(self):
-        rg = default_rng(238476)
-        obs = rg.random((11, 2))
-        inp_class_id = np.array([3, 3, 1, 2, 3, 1, 3, 3, 2, 3, 1])
-        (
-            mean_class_id,
-            class_cov,
-            prior_prob,
-            class_counts,
-            class_id,
-            mahal_class_id,
-        ) = gen_two_step_class_stats(obs, inp_class_id, thresh=1.5)
-        mahal_class_ref = np.array([3, 1, 1, 3, 0, 1, 3, 1, 2, 3, 1])
-        class_id_ref = np.array([1, 2, 3])
-        class_count_ref = np.array([3, 2, 5])
-        prior_prob_ref = np.array([0.3, 0.2, 0.5])
-        class_cov_ref = np.array(
+def test_mahal_class_thresh():
+    rg = default_rng(238476)
+    obs = rg.random((11, 2))
+    inp_class_id = np.array([3, 3, 1, 2, 3, 1, 3, 3, 2, 3, 1])
+    (
+        mean_class_id,
+        class_cov,
+        prior_prob,
+        class_counts,
+        class_id,
+        mahal_class_id,
+    ) = gen_two_step_class_stats(obs, inp_class_id, thresh=1.5)
+    mahal_class_ref = np.array([3, 1, 1, 3, 0, 1, 3, 1, 2, 3, 1])
+    class_id_ref = np.array([1, 2, 3])
+    class_count_ref = np.array([3, 2, 5])
+    prior_prob_ref = np.array([0.3, 0.2, 0.5])
+    class_cov_ref = np.array(
+        [
             [
-                [
-                    [0.05270089, 0.03950745, 0.17263269],
-                    [-0.01814353, -0.02054904, 0.11536174],
-                ],
-                [
-                    [-0.01814353, -0.02054904, 0.11536174],
-                    [0.00712315, 0.01068818, 0.08373218],
-                ],
-            ]
-        )
-        class_mean_ref = np.array(
+                [0.05270089, 0.03950745, 0.17263269],
+                [-0.01814353, -0.02054904, 0.11536174],
+            ],
             [
-                [0.7015159, 0.8764056],
-                [0.3122596, 0.2412942],
-                [0.3509461, 0.5514007],
-            ]
-        )
-        np.testing.assert_equal(mahal_class_id, mahal_class_ref)
-        np.testing.assert_equal(class_id, class_id_ref)
-        np.testing.assert_equal(class_counts, class_count_ref)
-        np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
-        np.testing.assert_almost_equal(class_cov, class_cov_ref)
-        np.testing.assert_almost_equal(mean_class_id, class_mean_ref)
+                [-0.01814353, -0.02054904, 0.11536174],
+                [0.00712315, 0.01068818, 0.08373218],
+            ],
+        ]
+    )
+    class_mean_ref = np.array(
+        [
+            [0.7015159, 0.8764056],
+            [0.3122596, 0.2412942],
+            [0.3509461, 0.5514007],
+        ]
+    )
+    np.testing.assert_equal(mahal_class_id, mahal_class_ref)
+    np.testing.assert_equal(class_id, class_id_ref)
+    np.testing.assert_equal(class_counts, class_count_ref)
+    np.testing.assert_almost_equal(prior_prob, prior_prob_ref)
+    np.testing.assert_almost_equal(class_cov, class_cov_ref)
+    np.testing.assert_almost_equal(mean_class_id, class_mean_ref)

--- a/tests/fluid_model_tests/test_oil_utilities.py
+++ b/tests/fluid_model_tests/test_oil_utilities.py
@@ -6,50 +6,56 @@ from rock_physics_open.fluid_models.oil_model.oil_utilities import (
 )
 
 
-class TestAsFloatArray:
-    def test_scalar_input(self):
-        result = as_float_array(3.14)
-        assert result.dtype == np.float64
-        assert result.ndim >= 1
-        np.testing.assert_array_equal(result, [3.14])
-
-    def test_integer_input(self):
-        result = as_float_array(5)
-        assert result.dtype == np.float64
-        np.testing.assert_array_equal(result, [5.0])
-
-    def test_float_array_input(self):
-        arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-        result = as_float_array(arr)
-        assert result.dtype == np.float64
-        np.testing.assert_array_equal(result, [1.0, 2.0, 3.0])
-
-    def test_single_element_array(self):
-        arr = np.array([42.0], dtype=np.float64)
-        result = as_float_array(arr)
-        assert result.dtype == np.float64
-        assert result.ndim >= 1
-        np.testing.assert_array_equal(result, [42.0])
-
-    def test_already_float64(self):
-        arr = np.array([1.5, 2.5], dtype=np.float64)
-        result = as_float_array(arr)
-        assert result.dtype == np.float64
-        np.testing.assert_array_equal(result, [1.5, 2.5])
+def test_scalar_input():
+    result = as_float_array(3.14)
+    assert result.dtype == np.float64
+    assert result.ndim >= 1
+    np.testing.assert_array_equal(result, [3.14])
 
 
-class TestInputsAreScalar:
-    def test_all_scalars(self):
-        assert inputs_are_scalar(1.0, 2.0, 3.0) is True
+def test_integer_input():
+    result = as_float_array(5)
+    assert result.dtype == np.float64
+    np.testing.assert_array_equal(result, [5.0])
 
-    def test_mixed_scalar_and_array(self):
-        assert inputs_are_scalar(1.0, np.array([2.0, 3.0])) is False
 
-    def test_all_arrays(self):
-        assert inputs_are_scalar(np.array([1.0]), np.array([2.0])) is False
+def test_float_array_input():
+    arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    result = as_float_array(arr)
+    assert result.dtype == np.float64
+    np.testing.assert_array_equal(result, [1.0, 2.0, 3.0])
 
-    def test_single_scalar(self):
-        assert inputs_are_scalar(42.0) is True
 
-    def test_zero_dim_array(self):
-        assert inputs_are_scalar(np.float64(1.0)) is True
+def test_single_element_array():
+    arr = np.array([42.0], dtype=np.float64)
+    result = as_float_array(arr)
+    assert result.dtype == np.float64
+    assert result.ndim >= 1
+    np.testing.assert_array_equal(result, [42.0])
+
+
+def test_already_float64():
+    arr = np.array([1.5, 2.5], dtype=np.float64)
+    result = as_float_array(arr)
+    assert result.dtype == np.float64
+    np.testing.assert_array_equal(result, [1.5, 2.5])
+
+
+def test_all_scalars():
+    assert inputs_are_scalar(1.0, 2.0, 3.0) is True
+
+
+def test_mixed_scalar_and_array():
+    assert inputs_are_scalar(1.0, np.array([2.0, 3.0])) is False
+
+
+def test_all_arrays():
+    assert inputs_are_scalar(np.array([1.0]), np.array([2.0])) is False
+
+
+def test_single_scalar():
+    assert inputs_are_scalar(42.0) is True
+
+
+def test_zero_dim_array():
+    assert inputs_are_scalar(np.float64(1.0)) is True

--- a/tests/gen_utilities_tests/test_dict_to_float.py
+++ b/tests/gen_utilities_tests/test_dict_to_float.py
@@ -1,9 +1,8 @@
 from rock_physics_open.equinor_utilities.gen_utilities import dict_value_to_float
 
 
-class TestDictToFloat:
-    def test_dict_to_float(self):
-        inp_dict = {"a": "1.0", "b": "2", "d": "[1.2, 4.5]", "e": "-3"}
-        ref_dict = {"a": 1.0, "b": 2.0, "d": [1.2, 4.5], "e": -3.0}
-        out_dict = dict_value_to_float(inp_dict)
-        assert out_dict == ref_dict
+def test_dict_to_float():
+    inp_dict = {"a": "1.0", "b": "2", "d": "[1.2, 4.5]", "e": "-3"}
+    ref_dict = {"a": 1.0, "b": 2.0, "d": [1.2, 4.5], "e": -3.0}
+    out_dict = dict_value_to_float(inp_dict)
+    assert out_dict == ref_dict

--- a/tests/gen_utilities_tests/test_dim_check_vector.py
+++ b/tests/gen_utilities_tests/test_dim_check_vector.py
@@ -4,60 +4,64 @@ import pandas as pd
 from rock_physics_open.equinor_utilities.gen_utilities import dim_check_vector
 
 
-class TestDimCheckVector:
-    def test_dim_check_vector_ok(self):
-        a = np.ones(11)
-        b = 42
-        c = True
-        a_ref = np.ones(11)
-        b_ref = np.ones_like(a) * 42
-        c_ref = np.ones_like(a).astype(bool)
-        a_out, b_out, c_out = dim_check_vector((a, b, c))
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
-        np.testing.assert_equal(c_out, c_ref)
+def test_dim_check_vector_ok():
+    a = np.ones(11)
+    b = 42
+    c = True
+    a_ref = np.ones(11)
+    b_ref = np.ones_like(a) * 42
+    c_ref = np.ones_like(a).astype(bool)
+    a_out, b_out, c_out = dim_check_vector((a, b, c))
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
+    np.testing.assert_equal(c_out, c_ref)
 
-    def test_dim_check_vector_single_np_array(self):
-        """Test that a single numpy array is returned as is."""
-        a = np.ones(11)
-        a_out = dim_check_vector(a)
-        np.testing.assert_equal(a_out, a)
 
-    def test_dim_check_vector_single_np_array_force(self):
-        """Test that a single numpy array is returned as is."""
-        a = np.ones(11).astype(float)
-        dtype = np.dtype(int)
-        a_out = dim_check_vector(a, force_type=dtype)
-        np.testing.assert_equal(a_out, a)
-        assert a_out.dtype == dtype
+def test_dim_check_vector_single_np_array():
+    """Test that a single numpy array is returned as is."""
+    a = np.ones(11)
+    a_out = dim_check_vector(a)
+    np.testing.assert_equal(a_out, a)
 
-    def test_dim_check_vector_single_df(self):
-        """Test that a single pandas dataframe is returned as is."""
-        a = np.ones((11, 3))
-        a_df = pd.DataFrame(a)
-        a_out = dim_check_vector(a_df)
-        pd.testing.assert_frame_equal(a_out, a_df)
 
-    def test_dim_check_vector_single_df_force(self):
-        """Test that a single pandas dataframe is returned as is."""
-        a = np.ones((11, 3))
-        a_df = pd.DataFrame(a).astype(float)
-        dtype = np.dtype(int)
-        a_out = dim_check_vector(a_df, force_type=dtype)
-        pd.testing.assert_frame_equal(left=a_out, right=a_df, check_dtype=False)
-        assert all(a_out.dtypes == dtype)
+def test_dim_check_vector_single_np_array_force():
+    """Test that a single numpy array is returned as is."""
+    a = np.ones(11).astype(float)
+    dtype = np.dtype(int)
+    a_out = dim_check_vector(a, force_type=dtype)
+    np.testing.assert_equal(a_out, a)
+    assert a_out.dtype == dtype
 
-    def test_dim_check_vector_force(self):
-        a = np.ones(11)
-        b = 42
-        c = True
-        a_ref = np.ones(11)
-        b_ref = (np.ones_like(a) * 42).astype(int)
-        c_ref = np.ones_like(a).astype(bool)
-        a_out, b_out, c_out = dim_check_vector((a, b, c), force_type=np.dtype(float))
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
-        np.testing.assert_equal(c_out, c_ref)
-        assert a_out.dtype == a_ref.dtype
-        assert b_out.dtype != b_ref.dtype
-        assert c_out.dtype != c_ref.dtype
+
+def test_dim_check_vector_single_df():
+    """Test that a single pandas dataframe is returned as is."""
+    a = np.ones((11, 3))
+    a_df = pd.DataFrame(a)
+    a_out = dim_check_vector(a_df)
+    pd.testing.assert_frame_equal(a_out, a_df)
+
+
+def test_dim_check_vector_single_df_force():
+    """Test that a single pandas dataframe is returned as is."""
+    a = np.ones((11, 3))
+    a_df = pd.DataFrame(a).astype(float)
+    dtype = np.dtype(int)
+    a_out = dim_check_vector(a_df, force_type=dtype)
+    pd.testing.assert_frame_equal(left=a_out, right=a_df, check_dtype=False)
+    assert all(a_out.dtypes == dtype)
+
+
+def test_dim_check_vector_force():
+    a = np.ones(11)
+    b = 42
+    c = True
+    a_ref = np.ones(11)
+    b_ref = (np.ones_like(a) * 42).astype(int)
+    c_ref = np.ones_like(a).astype(bool)
+    a_out, b_out, c_out = dim_check_vector((a, b, c), force_type=np.dtype(float))
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
+    np.testing.assert_equal(c_out, c_ref)
+    assert a_out.dtype == a_ref.dtype
+    assert b_out.dtype != b_ref.dtype
+    assert c_out.dtype != c_ref.dtype

--- a/tests/gen_utilities_tests/test_filter_input.py
+++ b/tests/gen_utilities_tests/test_filter_input.py
@@ -3,85 +3,89 @@ import numpy as np
 from rock_physics_open.equinor_utilities.gen_utilities import filter_input_log
 
 
-class TestFilterInput:
-    def test_filter_input(self):
-        a = np.ones(11).astype(float)
-        a[4] = np.nan
-        b = np.zeros_like(a)
-        b[1] = 3.14
-        b[9] = np.inf
-        b[10] = -np.inf
-        idx_ref = np.ones_like(a).astype(bool)
-        idx_ref[4] = False
-        idx_ref[9:] = False
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b))
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
+def test_filter_input():
+    a = np.ones(11).astype(float)
+    a[4] = np.nan
+    b = np.zeros_like(a)
+    b[1] = 3.14
+    b[9] = np.inf
+    b[10] = -np.inf
+    idx_ref = np.ones_like(a).astype(bool)
+    idx_ref[4] = False
+    idx_ref[9:] = False
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b))
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
 
-    def test_filter_input_negative(self):
-        a = np.ones(11).astype(float)
-        b = np.zeros_like(a)
-        b[4:6] = -1.0
-        idx_ref = np.ones_like(a).astype(bool)
-        idx_ref[4:6] = False
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b))
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
 
-    def test_filter_input_no_zero(self):
-        a = np.ones(11).astype(float)
-        b = np.zeros_like(a)
-        b[4:6] = 1.0
-        idx_ref = np.zeros_like(a).astype(bool)
-        idx_ref[4:6] = True
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b), no_zero=True)
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
+def test_filter_input_negative():
+    a = np.ones(11).astype(float)
+    b = np.zeros_like(a)
+    b[4:6] = -1.0
+    idx_ref = np.ones_like(a).astype(bool)
+    idx_ref[4:6] = False
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b))
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
 
-    def test_filter_input_positive(self):
-        a = np.ones(11).astype(float)
-        b = np.zeros_like(a)
-        b[4:6] = -1.0
-        idx_ref = np.zeros_like(a).astype(bool)
-        idx_ref[4:6] = True
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b), negative=True, positive=False)
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
 
-    def test_filter_input_bool(self):
-        a = np.ones(11).astype(float)
-        b = np.ones_like(a).astype(bool)
-        b[4:6] = False
-        idx_ref = np.ones_like(a).astype(bool)
-        idx_ref[4:6] = False
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b))
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
+def test_filter_input_no_zero():
+    a = np.ones(11).astype(float)
+    b = np.zeros_like(a)
+    b[4:6] = 1.0
+    idx_ref = np.zeros_like(a).astype(bool)
+    idx_ref[4:6] = True
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b), no_zero=True)
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
 
-    def test_filter_input_str(self):
-        a = np.ones(11).astype(float)
-        a[4:6] = -1.0
-        b = np.array(["NaN"] * 11)
-        idx_ref = np.ones_like(a).astype(bool)
-        idx_ref[4:6] = False
-        a_ref = a[idx_ref]
-        b_ref = b[idx_ref]
-        idx, (a_out, b_out) = filter_input_log((a, b))
-        np.testing.assert_equal(idx, idx_ref)
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
+
+def test_filter_input_positive():
+    a = np.ones(11).astype(float)
+    b = np.zeros_like(a)
+    b[4:6] = -1.0
+    idx_ref = np.zeros_like(a).astype(bool)
+    idx_ref[4:6] = True
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b), negative=True, positive=False)
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
+
+
+def test_filter_input_bool():
+    a = np.ones(11).astype(float)
+    b = np.ones_like(a).astype(bool)
+    b[4:6] = False
+    idx_ref = np.ones_like(a).astype(bool)
+    idx_ref[4:6] = False
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b))
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)
+
+
+def test_filter_input_str():
+    a = np.ones(11).astype(float)
+    a[4:6] = -1.0
+    b = np.array(["NaN"] * 11)
+    idx_ref = np.ones_like(a).astype(bool)
+    idx_ref[4:6] = False
+    a_ref = a[idx_ref]
+    b_ref = b[idx_ref]
+    idx, (a_out, b_out) = filter_input_log((a, b))
+    np.testing.assert_equal(idx, idx_ref)
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)

--- a/tests/gen_utilities_tests/test_filter_output.py
+++ b/tests/gen_utilities_tests/test_filter_output.py
@@ -3,17 +3,16 @@ import numpy as np
 from rock_physics_open.equinor_utilities.gen_utilities import filter_output
 
 
-class TestFilterOutput:
-    def test_filter_output(self):
-        a_inp = np.linspace(0, 1, 11)
-        b_inp = np.linspace(0, 1, 11) * 2
-        idx = np.ones(15).astype(bool)
-        idx[6:8] = False
-        idx[12:14] = False
-        a_ref = np.ones_like(idx) * np.nan
-        a_ref[idx] = a_inp
-        b_ref = np.ones_like(idx) * np.nan
-        b_ref[idx] = b_inp
-        a_out, b_out = filter_output(idx, (a_inp, b_inp))
-        np.testing.assert_equal(a_out, a_ref)
-        np.testing.assert_equal(b_out, b_ref)
+def test_filter_output():
+    a_inp = np.linspace(0, 1, 11)
+    b_inp = np.linspace(0, 1, 11) * 2
+    idx = np.ones(15).astype(bool)
+    idx[6:8] = False
+    idx[12:14] = False
+    a_ref = np.ones_like(idx) * np.nan
+    a_ref[idx] = a_inp
+    b_ref = np.ones_like(idx) * np.nan
+    b_ref[idx] = b_inp
+    a_out, b_out = filter_output(idx, (a_inp, b_inp))
+    np.testing.assert_equal(a_out, a_ref)
+    np.testing.assert_equal(b_out, b_ref)

--- a/tests/machine_learning_utilities_test/test_pressure_models.py
+++ b/tests/machine_learning_utilities_test/test_pressure_models.py
@@ -92,262 +92,250 @@ def invalid_input_data() -> dict[str, Any]:
     }
 
 
-# Test ExponentialPressureModel
-class TestExponentialPressureModel:
-    """Test cases for ExponentialPressureModel."""
+def test_exponential_initialization(exponential_model: ExponentialPressureModel):
+    """Test model initialization."""
+    assert exponential_model.a_factor == 0.5
+    assert exponential_model.b_factor == 1e7
+    assert exponential_model.max_pressure == 5e7
+    assert exponential_model.description == "Test exponential model"
 
-    def test_initialization(self, exponential_model: ExponentialPressureModel):
-        """Test model initialization."""
-        assert exponential_model.a_factor == 0.5
-        assert exponential_model.b_factor == 1e7
-        assert exponential_model.max_pressure == 5e7
-        assert exponential_model.description == "Test exponential model"
 
-    def test_validate_input_valid(
-        self,
-        exponential_model: ExponentialPressureModel,
-        exp_poly_valid_input: npt.NDArray[np.float64],
-    ):
-        """Test input validation with valid data."""
-        result = exponential_model.validate_input(exp_poly_valid_input)
-        np.testing.assert_array_equal(result, exp_poly_valid_input)
+def test_validate_input_valid(
+    exponential_model: ExponentialPressureModel,
+    exp_poly_valid_input: npt.NDArray[np.float64],
+):
+    """Test input validation with valid data."""
+    result = exponential_model.validate_input(exp_poly_valid_input)
+    np.testing.assert_array_equal(result, exp_poly_valid_input)
 
-    def test_validate_input_invalid(
-        self,
-        exponential_model: ExponentialPressureModel,
-        invalid_input_data: dict[str, Any],
-    ):
-        """Test validation with invalid input formats."""
-        test_cases = [
-            ("wrong_dimensions", "Input must be \\(n,3\\)"),
-            ("wrong_columns_exp", "Input must be \\(n,3\\)"),
-            ("empty_array", None),  # Empty array might be valid
-        ]
 
-        for case_name, expected_error in test_cases:
-            if expected_error is None:
-                continue  # Skip cases where we don't expect an error
+def test_validate_input_invalid(
+    exponential_model: ExponentialPressureModel,
+    invalid_input_data: dict[str, Any],
+):
+    """Test validation with invalid input formats."""
+    test_cases = [
+        ("wrong_dimensions", "Input must be \\(n,3\\)"),
+        ("wrong_columns_exp", "Input must be \\(n,3\\)"),
+        ("empty_array", None),  # Empty array might be valid
+    ]
 
-            with pytest.raises(ValueError, match=expected_error):
-                _ = exponential_model.validate_input(invalid_input_data[case_name])
+    for case_name, expected_error in test_cases:
+        if expected_error is None:
+            continue  # Skip cases where we don't expect an error
 
-    @pytest.mark.parametrize("case", ["in_situ", "depleted"])
-    def test_predict_abs(
-        self,
-        exponential_model: ExponentialPressureModel,
-        exp_poly_valid_input: npt.NDArray[np.float64],
-        case: str,
-    ):
-        """Test absolute prediction for different cases."""
-        result = exponential_model.predict_abs(exp_poly_valid_input, case=case)
-        assert len(result) == 2
-        assert np.all(result > 0)
+        with pytest.raises(ValueError, match=expected_error):
+            _ = exponential_model.validate_input(invalid_input_data[case_name])
 
-    def test_predict_differential(
-        self,
-        exponential_model: ExponentialPressureModel,
-        exp_poly_valid_input: npt.NDArray[np.float64],
-    ):
-        """Test differential prediction."""
-        result = exponential_model.predict(exp_poly_valid_input)
-        assert len(result) == 2
 
-    def test_predict_max(
-        self,
-        exponential_model: ExponentialPressureModel,
-        exp_poly_valid_input: npt.NDArray[np.float64],
-    ):
-        """Test prediction with max pressure."""
-        result = exponential_model.predict_max(exp_poly_valid_input)
-        assert len(result) == 2
+@pytest.mark.parametrize("case", ["in_situ", "depleted"])
+def test_exponential_predict_abs(
+    exponential_model: ExponentialPressureModel,
+    exp_poly_valid_input: npt.NDArray[np.float64],
+    case: str,
+):
+    """Test absolute prediction for different cases."""
+    result = exponential_model.predict_abs(exp_poly_valid_input, case=case)
+    assert len(result) == 2
+    assert np.all(result > 0)
 
-    def test_predict_max_no_max_pressure(
-        self, exp_poly_valid_input: npt.NDArray[np.float64]
-    ):
-        """Test predict_max without max_pressure set."""
-        model_no_max = ExponentialPressureModel(0.5, 1e7)
-        with pytest.raises(ValueError, match='Field "model_max_pressure" is not set'):
-            _ = model_no_max.predict_max(exp_poly_valid_input)
 
-    def test_todict(self, exponential_model: ExponentialPressureModel):
-        """Test dictionary conversion."""
-        result = exponential_model.todict()
-        expected_keys = {"a_factor", "b_factor", "model_max_pressure", "description"}
-        assert set(result.keys()) == expected_keys
+def test_predict_differential(
+    exponential_model: ExponentialPressureModel,
+    exp_poly_valid_input: npt.NDArray[np.float64],
+):
+    """Test differential prediction."""
+    result = exponential_model.predict(exp_poly_valid_input)
+    assert len(result) == 2
 
-    def test_save_load(self, exponential_model: ExponentialPressureModel):
-        """Test save and load functionality."""
+
+def test_predict_max(
+    exponential_model: ExponentialPressureModel,
+    exp_poly_valid_input: npt.NDArray[np.float64],
+):
+    """Test prediction with max pressure."""
+    result = exponential_model.predict_max(exp_poly_valid_input)
+    assert len(result) == 2
+
+
+def test_predict_max_no_max_pressure(exp_poly_valid_input: npt.NDArray[np.float64]):
+    """Test predict_max without max_pressure set."""
+    model_no_max = ExponentialPressureModel(0.5, 1e7)
+    with pytest.raises(ValueError, match='Field "model_max_pressure" is not set'):
+        _ = model_no_max.predict_max(exp_poly_valid_input)
+
+
+def test_exponential_todict(exponential_model: ExponentialPressureModel):
+    """Test dictionary conversion."""
+    result = exponential_model.todict()
+    expected_keys = {"a_factor", "b_factor", "model_max_pressure", "description"}
+    assert set(result.keys()) == expected_keys
+
+
+def test_exponential_save_load(exponential_model: ExponentialPressureModel):
+    """Test save and load functionality."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        exponential_model.save(tmp_path)
+        loaded_model = ExponentialPressureModel.load(tmp_path)
+
+        assert loaded_model.a_factor == exponential_model.a_factor
+        assert loaded_model.b_factor == exponential_model.b_factor
+        assert loaded_model.max_pressure == exponential_model.max_pressure
+    finally:
+        Path(tmp_path).unlink()
+
+
+# Test PolynomialPressureModel
+def test_polynomial_initialization(polynomial_model: PolynomialPressureModel):
+    """Test model initialization."""
+    assert polynomial_model.weights == [1.0, 2e-8, -1e-16]
+
+
+def test_polynomial_predict_abs_no_weights(
+    exp_poly_valid_input: npt.NDArray[np.float64],
+):
+    """Test prediction with empty weights."""
+    model_no_weights = PolynomialPressureModel([])
+    with pytest.raises(ValueError, match='Field "weights" is not set'):
+        _ = model_no_weights.predict_abs(exp_poly_valid_input)
+
+
+def test_polynomial_predict_abs(
+    polynomial_model: PolynomialPressureModel,
+    exp_poly_valid_input: npt.NDArray[np.float64],
+):
+    """Test absolute prediction."""
+    result = polynomial_model.predict_abs(exp_poly_valid_input, case="in_situ")
+    assert len(result) == 2
+    assert np.all(result > 0)
+
+
+# Test SigmoidalPressureModel
+def test_sigmoidal_properties(sigmoidal_model: SigmoidalPressureModel):
+    """Test model properties."""
+    assert sigmoidal_model.phi_amplitude == 1000.0
+    assert sigmoidal_model.phi_median_point == 0.2
+    assert sigmoidal_model.p_eff_median_point == 1.5e7
+
+
+def test_sigmoidal_predict_abs(
+    sigmoidal_model: SigmoidalPressureModel,
+    sigmoidal_valid_input: npt.NDArray[np.float64],
+):
+    """Test absolute prediction."""
+    result = sigmoidal_model.predict_abs(sigmoidal_valid_input, case="in_situ")
+    assert len(result) == 2
+    assert np.all(result > 0)
+
+
+def test_sigmoidal_input_validation(sigmoidal_model: SigmoidalPressureModel):
+    """Test input validation with wrong format."""
+    invalid_input = np.array([[0.2, 2e7]])  # Missing column
+    with pytest.raises(ValueError, match="Input must be \\(n,3\\)"):
+        _ = sigmoidal_model.validate_input(invalid_input)
+
+
+# Integration Tests
+@pytest.mark.parametrize(
+    (
+        "model_fixture",
+        "input_fixture",
+    ),
+    [
+        ("exponential_model", "exp_poly_valid_input"),
+        ("polynomial_model", "exp_poly_valid_input"),
+        ("sigmoidal_model", "sigmoidal_valid_input"),
+    ],
+)
+def test_all_models_predict_interface(
+    request: pytest.FixtureRequest, model_fixture: str, input_fixture: str
+):
+    """Test that all models implement the required interface."""
+    model = request.getfixturevalue(model_fixture)
+    test_input = request.getfixturevalue(input_fixture)
+
+    # Test interface methods exist and work
+    assert hasattr(model, "predict_abs")
+    assert hasattr(model, "predict")
+    assert hasattr(model, "predict_max")
+    assert hasattr(model, "validate_input")
+    assert hasattr(model, "todict")
+    assert hasattr(model, "save")
+
+    result_abs = model.predict_abs(test_input)
+    result_diff = model.predict(test_input)
+    result_max = model.predict_max(test_input)
+
+    assert len(result_abs) == len(test_input)
+    assert len(result_diff) == len(test_input)
+    assert len(result_max) == len(test_input)
+
+
+def test_model_serialization_consistency(
+    exponential_model: ExponentialPressureModel,
+    polynomial_model: PolynomialPressureModel,
+    sigmoidal_model: SigmoidalPressureModel,
+):
+    """Test that all models can be serialized and deserialized consistently."""
+    models = [exponential_model, polynomial_model, sigmoidal_model]
+
+    for model in models:
+        # Test dictionary conversion
+        model_dict = model.todict()
+        assert isinstance(model_dict, dict)
+        assert len(model_dict) > 0
+
+        # Test save/load cycle
         with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as tmp:
             tmp_path = tmp.name
 
         try:
-            exponential_model.save(tmp_path)
-            loaded_model = ExponentialPressureModel.load(tmp_path)
+            model.save(tmp_path)
+            loaded_model = type(model).load(tmp_path)
 
-            assert loaded_model.a_factor == exponential_model.a_factor
-            assert loaded_model.b_factor == exponential_model.b_factor
-            assert loaded_model.max_pressure == exponential_model.max_pressure
+            # Compare dictionaries
+            original_dict = model.todict()
+            loaded_dict = loaded_model.todict()
+
+            assert original_dict == loaded_dict
+
         finally:
             Path(tmp_path).unlink()
 
 
-# Test PolynomialPressureModel
-class TestPolynomialPressureModel:
-    """Test cases for PolynomialPressureModel."""
-
-    def test_initialization(self, polynomial_model: PolynomialPressureModel):
-        """Test model initialization."""
-        assert polynomial_model.weights == [1.0, 2e-8, -1e-16]
-
-    def test_predict_abs_no_weights(
-        self, exp_poly_valid_input: npt.NDArray[np.float64]
-    ):
-        """Test prediction with empty weights."""
-        model_no_weights = PolynomialPressureModel([])
-        with pytest.raises(ValueError, match='Field "weights" is not set'):
-            _ = model_no_weights.predict_abs(exp_poly_valid_input)
-
-    def test_predict_abs(
-        self,
-        polynomial_model: PolynomialPressureModel,
-        exp_poly_valid_input: npt.NDArray[np.float64],
-    ):
-        """Test absolute prediction."""
-        result = polynomial_model.predict_abs(exp_poly_valid_input, case="in_situ")
-        assert len(result) == 2
-        assert np.all(result > 0)
-
-
-# Test SigmoidalPressureModel
-class TestSigmoidalPressureModel:
-    """Test cases for SigmoidalPressureModel."""
-
-    def test_properties(self, sigmoidal_model: SigmoidalPressureModel):
-        """Test model properties."""
-        assert sigmoidal_model.phi_amplitude == 1000.0
-        assert sigmoidal_model.phi_median_point == 0.2
-        assert sigmoidal_model.p_eff_median_point == 1.5e7
-
-    def test_predict_abs(
-        self,
-        sigmoidal_model: SigmoidalPressureModel,
-        sigmoidal_valid_input: npt.NDArray[np.float64],
-    ):
-        """Test absolute prediction."""
-        result = sigmoidal_model.predict_abs(sigmoidal_valid_input, case="in_situ")
-        assert len(result) == 2
-        assert np.all(result > 0)
-
-    def test_input_validation(self, sigmoidal_model: SigmoidalPressureModel):
-        """Test input validation with wrong format."""
-        invalid_input = np.array([[0.2, 2e7]])  # Missing column
-        with pytest.raises(ValueError, match="Input must be \\(n,3\\)"):
-            _ = sigmoidal_model.validate_input(invalid_input)
-
-
-# Integration Tests
-class TestModelIntegration:
-    """Integration tests across model types."""
-
-    @pytest.mark.parametrize(
-        (
-            "model_fixture",
-            "input_fixture",
-        ),
-        [
-            ("exponential_model", "exp_poly_valid_input"),
-            ("polynomial_model", "exp_poly_valid_input"),
-            ("sigmoidal_model", "sigmoidal_valid_input"),
-        ],
-    )
-    def test_all_models_predict_interface(
-        self, request: pytest.FixtureRequest, model_fixture: str, input_fixture: str
-    ):
-        """Test that all models implement the required interface."""
-        model = request.getfixturevalue(model_fixture)
-        test_input = request.getfixturevalue(input_fixture)
-
-        # Test interface methods exist and work
-        assert hasattr(model, "predict_abs")
-        assert hasattr(model, "predict")
-        assert hasattr(model, "predict_max")
-        assert hasattr(model, "validate_input")
-        assert hasattr(model, "todict")
-        assert hasattr(model, "save")
-
-        result_abs = model.predict_abs(test_input)
-        result_diff = model.predict(test_input)
-        result_max = model.predict_max(test_input)
-
-        assert len(result_abs) == len(test_input)
-        assert len(result_diff) == len(test_input)
-        assert len(result_max) == len(test_input)
-
-    def test_model_serialization_consistency(
-        self,
-        exponential_model: ExponentialPressureModel,
-        polynomial_model: PolynomialPressureModel,
-        sigmoidal_model: SigmoidalPressureModel,
-    ):
-        """Test that all models can be serialized and deserialized consistently."""
-        models = [exponential_model, polynomial_model, sigmoidal_model]
-
-        for model in models:
-            # Test dictionary conversion
-            model_dict = model.todict()
-            assert isinstance(model_dict, dict)
-            assert len(model_dict) > 0
-
-            # Test save/load cycle
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as tmp:
-                tmp_path = tmp.name
-
-            try:
-                model.save(tmp_path)
-                loaded_model = type(model).load(tmp_path)
-
-                # Compare dictionaries
-                original_dict = model.todict()
-                loaded_dict = loaded_model.todict()
-
-                assert original_dict == loaded_dict
-
-            finally:
-                Path(tmp_path).unlink()
-
-
 # Performance Tests
-class TestModelPerformance:
-    """Performance and stress tests."""
+@pytest.mark.parametrize("n_samples", [100, 1000, 10000])
+def test_exponential_model_performance(
+    exponential_model: ExponentialPressureModel, n_samples: int
+):
+    """Test exponential model performance with different data sizes."""
+    # Generate test data
+    rng = np.random.default_rng(42)
+    velocities = rng.uniform(2500, 4000, n_samples)
+    p_in_situ = rng.uniform(1e7, 3e7, n_samples)
+    p_depleted = rng.uniform(0.5e7, 1.5e7, n_samples)
+    test_data = np.column_stack([velocities, p_in_situ, p_depleted])
 
-    @pytest.mark.parametrize("n_samples", [100, 1000, 10000])
-    def test_exponential_model_performance(
-        self, exponential_model: ExponentialPressureModel, n_samples: int
-    ):
-        """Test exponential model performance with different data sizes."""
-        # Generate test data
-        rng = np.random.default_rng(42)
-        velocities = rng.uniform(2500, 4000, n_samples)
-        p_in_situ = rng.uniform(1e7, 3e7, n_samples)
-        p_depleted = rng.uniform(0.5e7, 1.5e7, n_samples)
-        test_data = np.column_stack([velocities, p_in_situ, p_depleted])
+    # Test prediction (should complete without errors)
+    result = exponential_model.predict_abs(test_data)
+    assert len(result) == n_samples
+    assert np.all(np.isfinite(result))
 
-        # Test prediction (should complete without errors)
+
+def test_memory_usage(exponential_model: ExponentialPressureModel):
+    """Test that models don't leak memory with repeated calls."""
+    # Create moderate size dataset
+    n_samples = 10000
+    rng = np.random.default_rng(42)
+    velocities = rng.uniform(2500, 4000, n_samples)
+    p_in_situ = rng.uniform(1e7, 3e7, n_samples)
+    p_depleted = rng.uniform(0.5e7, 1.5e7, n_samples)
+    test_data = np.column_stack([velocities, p_in_situ, p_depleted])
+
+    # Run multiple predictions
+    for _ in range(10):
         result = exponential_model.predict_abs(test_data)
-        assert len(result) == n_samples
-        assert np.all(np.isfinite(result))
-
-    def test_memory_usage(self, exponential_model: ExponentialPressureModel):
-        """Test that models don't leak memory with repeated calls."""
-        # Create moderate size dataset
-        n_samples = 10000
-        rng = np.random.default_rng(42)
-        velocities = rng.uniform(2500, 4000, n_samples)
-        p_in_situ = rng.uniform(1e7, 3e7, n_samples)
-        p_depleted = rng.uniform(0.5e7, 1.5e7, n_samples)
-        test_data = np.column_stack([velocities, p_in_situ, p_depleted])
-
-        # Run multiple predictions
-        for _ in range(10):
-            result = exponential_model.predict_abs(test_data)
-            del result  # Explicitly delete to test memory cleanup
+        del result  # Explicitly delete to test memory cleanup

--- a/tests/std_functions_tests/test_dvorkin_nur.py
+++ b/tests/std_functions_tests/test_dvorkin_nur.py
@@ -3,46 +3,45 @@ import numpy as np
 from rock_physics_open.equinor_utilities.std_functions import dvorkin_contact_cement
 
 
-class TestDvorkinNur:
-    def test_dvorkin_nur(self):
-        frac_cem = np.linspace(0.01, 0.1, 10)
-        por0_sst = 0.4 * np.ones(10)
-        mu0_sst = 44e9 * np.ones(10)
-        k0_sst = 36.8e9 * np.ones(10)
-        mu0_cem = 32e9 * np.ones(10)
-        k0_cem = 71e9 * np.ones(10)
-        vs_red = 0.25 * np.ones(10)
-        c = 9.0
-        k, mu = dvorkin_contact_cement(
-            frac_cem, por0_sst, mu0_sst, k0_sst, mu0_cem, k0_cem, vs_red, c
-        )
-        k_expected = np.array(
-            [
-                2.8039220,
-                3.9241764,
-                4.7745324,
-                5.4851787,
-                6.1065427,
-                6.6644869,
-                7.1743746,
-                7.6462158,
-                8.0869637,
-                8.5016807,
-            ]
-        )
-        mu_expected = np.array(
-            [
-                2.2131204,
-                3.0849503,
-                3.745499,
-                4.2966804,
-                4.7779701,
-                5.2096136,
-                5.6036376,
-                5.9678782,
-                6.3077783,
-                6.6273009,
-            ]
-        )
-        np.testing.assert_almost_equal(k / 1.0e9, k_expected)
-        np.testing.assert_almost_equal(mu / 1.0e9, mu_expected)
+def test_dvorkin_nur():
+    frac_cem = np.linspace(0.01, 0.1, 10)
+    por0_sst = 0.4 * np.ones(10)
+    mu0_sst = 44e9 * np.ones(10)
+    k0_sst = 36.8e9 * np.ones(10)
+    mu0_cem = 32e9 * np.ones(10)
+    k0_cem = 71e9 * np.ones(10)
+    vs_red = 0.25 * np.ones(10)
+    c = 9.0
+    k, mu = dvorkin_contact_cement(
+        frac_cem, por0_sst, mu0_sst, k0_sst, mu0_cem, k0_cem, vs_red, c
+    )
+    k_expected = np.array(
+        [
+            2.8039220,
+            3.9241764,
+            4.7745324,
+            5.4851787,
+            6.1065427,
+            6.6644869,
+            7.1743746,
+            7.6462158,
+            8.0869637,
+            8.5016807,
+        ]
+    )
+    mu_expected = np.array(
+        [
+            2.2131204,
+            3.0849503,
+            3.745499,
+            4.2966804,
+            4.7779701,
+            5.2096136,
+            5.6036376,
+            5.9678782,
+            6.3077783,
+            6.6273009,
+        ]
+    )
+    np.testing.assert_almost_equal(k / 1.0e9, k_expected)
+    np.testing.assert_almost_equal(mu / 1.0e9, mu_expected)

--- a/tests/std_functions_tests/test_gassmann.py
+++ b/tests/std_functions_tests/test_gassmann.py
@@ -6,32 +6,28 @@ from rock_physics_open.equinor_utilities.std_functions import (
     gassmann_dry,
 )
 
+k_brine = np.array([2.8e9, 2.8e9, 2.8e9])
+phie = np.array([0.0, 0.35, 0.1])
+k_min = np.array([36.6e9, 36.6e9, 36.6e9])
+k_dry = np.array([36.6e9, 15.0e9, 28.0e9])
+k_oil = np.array([0.8e9, 0.8e9, 0.8e9])
 
-class TestGassmann:
-    def setup_gassmann(self):
-        k_brine = np.array([2.8e9, 2.8e9, 2.8e9])
-        phie = np.array([0.0, 0.35, 0.1])
-        k_min = np.array([36.6e9, 36.6e9, 36.6e9])
-        k_dry = np.array([36.6e9, 15.0e9, 28.0e9])
-        k_oil = np.array([0.8e9, 0.8e9, 0.8e9])
-        return k_brine, phie, k_min, k_dry, k_oil
 
-    def test_gassmann(self):
-        k_brine, phie, k_min, k_dry, _ = self.setup_gassmann()
-        k_sat = gassmann(k_dry, phie, k_brine, k_min)
-        ksat_ref = np.array([36.6, 17.6473742, 29.4012504])
-        np.testing.assert_almost_equal(k_sat / 1.0e9, ksat_ref)
+def test_gassmann():
+    k_sat = gassmann(k_dry, phie, k_brine, k_min)
+    ksat_ref = np.array([36.6, 17.6473742, 29.4012504])
+    np.testing.assert_almost_equal(k_sat / 1.0e9, ksat_ref)
 
-    def test_gassmann2(self):
-        k_brine, phie, k_min, k_dry, k_oil = self.setup_gassmann()
-        k_sat = gassmann(k_dry, phie, k_brine, k_min)
-        k_sat2 = gassmann2(k_sat, k_brine, k_oil, phie, k_min)
-        ksat2_ref = np.array([36.6, 15.7843355, 28.4290396])
-        np.testing.assert_almost_equal(k_sat2 / 1.0e9, ksat2_ref)
 
-    def test_gassmann_dry(self):
-        k_brine, phie, k_min, k_dry, _ = self.setup_gassmann()
-        k_sat = gassmann(k_dry, phie, k_brine, k_min)
-        k_dry2 = gassmann_dry(k_sat, phie, k_brine, k_min)
-        k_dry2_ref = np.array([36.6e9, 15.0e9, 28.0e9]) / 1e9
-        np.testing.assert_almost_equal(k_dry2 / 1.0e9, k_dry2_ref)
+def test_gassmann2():
+    k_sat = gassmann(k_dry, phie, k_brine, k_min)
+    k_sat2 = gassmann2(k_sat, k_brine, k_oil, phie, k_min)
+    ksat2_ref = np.array([36.6, 15.7843355, 28.4290396])
+    np.testing.assert_almost_equal(k_sat2 / 1.0e9, ksat2_ref)
+
+
+def test_gassmann_dry():
+    k_sat = gassmann(k_dry, phie, k_brine, k_min)
+    k_dry2 = gassmann_dry(k_sat, phie, k_brine, k_min)
+    k_dry2_ref = np.array([36.6e9, 15.0e9, 28.0e9]) / 1e9
+    np.testing.assert_almost_equal(k_dry2 / 1.0e9, k_dry2_ref)

--- a/tests/std_functions_tests/test_hashin_shtrikman.py
+++ b/tests/std_functions_tests/test_hashin_shtrikman.py
@@ -7,158 +7,154 @@ from rock_physics_open.equinor_utilities.std_functions import (
     multi_hashin_shtrikman,
 )
 
+k1 = np.ones(11) * 36.6e9
+mu1 = np.ones(11) * 44.0e9
+k2 = np.ones(11) * 71.0e9
+mu2 = np.ones(11) * 32.0e9
+f1 = np.linspace(0, 1, 11)
 
-class TestHashinShtrikman:
-    def setup_hs(self):
-        k1 = np.ones(11) * 36.6e9
-        mu1 = np.ones(11) * 44.0e9
-        k2 = np.ones(11) * 71.0e9
-        mu2 = np.ones(11) * 32.0e9
-        f1 = np.linspace(0, 1, 11)
-        return k1, mu1, k2, mu2, f1
 
-    def test_hs(self):
-        k1, mu1, k2, mu2, f1 = self.setup_hs()
-        k_hs, mu_hs = hashin_shtrikman(k1, mu1, k2, mu2, f1)
-        k_hs_ref = np.array(
-            [
-                71.0,
-                66.481021,
-                62.266414,
-                58.32643,
-                54.635074,
-                51.169532,
-                47.909697,
-                44.837783,
-                41.937995,
-                39.196261,
-                36.6,
-            ]
-        )
-        mu_hs_ref = np.array(
-            [
-                32.0,
-                33.0436742,
-                34.1180058,
-                35.2243656,
-                36.3642075,
-                37.5390749,
-                38.7506074,
-                40.0005484,
-                41.290754,
-                42.6232015,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_hs / 1e9, k_hs_ref, decimal=6)
-        np.testing.assert_almost_equal(mu_hs / 1e9, mu_hs_ref, decimal=6)
+def test_hs():
+    k_hs, mu_hs = hashin_shtrikman(k1, mu1, k2, mu2, f1)
+    k_hs_ref = np.array(
+        [
+            71.0,
+            66.481021,
+            62.266414,
+            58.32643,
+            54.635074,
+            51.169532,
+            47.909697,
+            44.837783,
+            41.937995,
+            39.196261,
+            36.6,
+        ]
+    )
+    mu_hs_ref = np.array(
+        [
+            32.0,
+            33.0436742,
+            34.1180058,
+            35.2243656,
+            36.3642075,
+            37.5390749,
+            38.7506074,
+            40.0005484,
+            41.290754,
+            42.6232015,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_hs / 1e9, k_hs_ref, decimal=6)
+    np.testing.assert_almost_equal(mu_hs / 1e9, mu_hs_ref, decimal=6)
 
-    def test_hs_ave(self):
-        k1, mu1, k2, mu2, f1 = self.setup_hs()
-        k_av, mu_av = hashin_shtrikman_average(k1, mu1, k2, mu2, f1)
-        k_av_ref = np.array(
-            [
-                71.0,
-                66.376654,
-                62.094281,
-                58.116259,
-                54.411059,
-                50.951386,
-                47.71349,
-                44.6766,
-                41.822475,
-                39.135024,
-                36.6,
-            ]
-        )
-        mu_av_ref = np.array(
-            [
-                32.0,
-                33.038928,
-                34.109311,
-                35.2126,
-                36.350338,
-                37.524166,
-                38.735829,
-                39.987191,
-                41.280235,
-                42.617082,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_av / 1e9, k_av_ref, decimal=6)
-        np.testing.assert_almost_equal(mu_av / 1e9, mu_av_ref, decimal=6)
 
-    def test_hsw(self):
-        k1, mu1, k2, mu2, f1 = self.setup_hs()
-        k_hsw, mu_hsw = hashin_shtrikman_walpole(k1, mu1, k2, mu2, f1, bound="lower")
-        k_hsw_ref = np.array(
-            [
-                71.0,
-                66.272288,
-                61.922148,
-                57.906087,
-                54.187043,
-                50.733241,
-                47.517283,
-                44.515417,
-                41.706955,
-                39.073787,
-                36.6,
-            ]
-        )
-        mu_hsw_ref = np.array(
-            [
-                32.0,
-                33.024474,
-                34.082798,
-                35.176679,
-                36.307938,
-                37.478526,
-                38.690529,
-                39.946185,
-                41.247896,
-                42.598241,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_hsw / 1e9, k_hsw_ref, decimal=6)
-        np.testing.assert_almost_equal(mu_hsw / 1e9, mu_hsw_ref, decimal=6)
+def test_hs_ave():
+    k_av, mu_av = hashin_shtrikman_average(k1, mu1, k2, mu2, f1)
+    k_av_ref = np.array(
+        [
+            71.0,
+            66.376654,
+            62.094281,
+            58.116259,
+            54.411059,
+            50.951386,
+            47.71349,
+            44.6766,
+            41.822475,
+            39.135024,
+            36.6,
+        ]
+    )
+    mu_av_ref = np.array(
+        [
+            32.0,
+            33.038928,
+            34.109311,
+            35.2126,
+            36.350338,
+            37.524166,
+            38.735829,
+            39.987191,
+            41.280235,
+            42.617082,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_av / 1e9, k_av_ref, decimal=6)
+    np.testing.assert_almost_equal(mu_av / 1e9, mu_av_ref, decimal=6)
 
-    def test_multi_hs(self):
-        k1, mu1, k2, mu2, f1 = self.setup_hs()
-        k_m_hs, mu_m_hs = multi_hashin_shtrikman(
-            k1, mu1, f1, k2, mu2, 1.0 - f1, mode="lower"
-        )
-        k_m_ref = np.array(
-            [
-                71.0,
-                66.272288,
-                61.922148,
-                57.906087,
-                54.187043,
-                50.733241,
-                47.517283,
-                44.515417,
-                41.706955,
-                39.073787,
-                36.6,
-            ]
-        )
-        mu_m_ref = np.array(
-            [
-                32.0,
-                33.024474,
-                34.082798,
-                35.176679,
-                36.307938,
-                37.478526,
-                38.690529,
-                39.946185,
-                41.247896,
-                42.598241,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_m_hs / 1e9, k_m_ref, decimal=6)
-        np.testing.assert_almost_equal(mu_m_hs / 1e9, mu_m_ref, decimal=6)
+
+def test_hsw():
+    k_hsw, mu_hsw = hashin_shtrikman_walpole(k1, mu1, k2, mu2, f1, bound="lower")
+    k_hsw_ref = np.array(
+        [
+            71.0,
+            66.272288,
+            61.922148,
+            57.906087,
+            54.187043,
+            50.733241,
+            47.517283,
+            44.515417,
+            41.706955,
+            39.073787,
+            36.6,
+        ]
+    )
+    mu_hsw_ref = np.array(
+        [
+            32.0,
+            33.024474,
+            34.082798,
+            35.176679,
+            36.307938,
+            37.478526,
+            38.690529,
+            39.946185,
+            41.247896,
+            42.598241,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_hsw / 1e9, k_hsw_ref, decimal=6)
+    np.testing.assert_almost_equal(mu_hsw / 1e9, mu_hsw_ref, decimal=6)
+
+
+def test_multi_hs():
+    k_m_hs, mu_m_hs = multi_hashin_shtrikman(
+        k1, mu1, f1, k2, mu2, 1.0 - f1, mode="lower"
+    )
+    k_m_ref = np.array(
+        [
+            71.0,
+            66.272288,
+            61.922148,
+            57.906087,
+            54.187043,
+            50.733241,
+            47.517283,
+            44.515417,
+            41.706955,
+            39.073787,
+            36.6,
+        ]
+    )
+    mu_m_ref = np.array(
+        [
+            32.0,
+            33.024474,
+            34.082798,
+            35.176679,
+            36.307938,
+            37.478526,
+            38.690529,
+            39.946185,
+            41.247896,
+            42.598241,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_m_hs / 1e9, k_m_ref, decimal=6)
+    np.testing.assert_almost_equal(mu_m_hs / 1e9, mu_m_ref, decimal=6)

--- a/tests/std_functions_tests/test_hertz_mindlin.py
+++ b/tests/std_functions_tests/test_hertz_mindlin.py
@@ -3,44 +3,43 @@ import numpy as np
 from rock_physics_open.equinor_utilities.std_functions import hertz_mindlin
 
 
-class TestHertzMindlin:
-    def test_hertz_mindlin(self):
-        k1 = np.ones(11) * 36.6e9
-        mu1 = np.ones(11) * 44.0e9
-        phi_c = np.ones(11) * 0.4
-        p = np.ones(11) * 30e6
-        shear_red = np.linspace(0.0, 1.0, 11)
-        n = np.ones(11) * 7.5
-        k_dry, mu_dry = hertz_mindlin(k1, mu1, phi_c, p, shear_red, n)
-        k_dry_ref = np.array(
-            [
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-                1.9720104,
-            ]
-        )
-        mu_dry_ref = np.array(
-            [
-                1.1832062,
-                1.354167,
-                1.5251277,
-                1.6960885,
-                1.8670492,
-                2.0380099,
-                2.2089707,
-                2.3799314,
-                2.5508921,
-                2.7218529,
-                2.8928136,
-            ]
-        )
-        np.testing.assert_almost_equal(k_dry / 1e9, k_dry_ref)
-        np.testing.assert_almost_equal(mu_dry / 1e9, mu_dry_ref)
+def test_hertz_mindlin():
+    k1 = np.ones(11) * 36.6e9
+    mu1 = np.ones(11) * 44.0e9
+    phi_c = np.ones(11) * 0.4
+    p = np.ones(11) * 30e6
+    shear_red = np.linspace(0.0, 1.0, 11)
+    n = np.ones(11) * 7.5
+    k_dry, mu_dry = hertz_mindlin(k1, mu1, phi_c, p, shear_red, n)
+    k_dry_ref = np.array(
+        [
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+            1.9720104,
+        ]
+    )
+    mu_dry_ref = np.array(
+        [
+            1.1832062,
+            1.354167,
+            1.5251277,
+            1.6960885,
+            1.8670492,
+            2.0380099,
+            2.2089707,
+            2.3799314,
+            2.5508921,
+            2.7218529,
+            2.8928136,
+        ]
+    )
+    np.testing.assert_almost_equal(k_dry / 1e9, k_dry_ref)
+    np.testing.assert_almost_equal(mu_dry / 1e9, mu_dry_ref)

--- a/tests/std_functions_tests/test_moduli_velocity.py
+++ b/tests/std_functions_tests/test_moduli_velocity.py
@@ -5,13 +5,49 @@ import numpy as np
 from rock_physics_open.equinor_utilities.std_functions import moduli, velocity
 
 
-class TestModuliVelocity:
-    def test_moduli(self):
-        vp = np.linspace(0.8, 1.2, 11) * 3500.0
-        vs = np.linspace(0.8, 1.2, 11) * 1200.0
-        rho = np.ones(11) * 2650.0
-        k, mu = moduli(vp, vs, rho)
-        k_ref = np.array(
+def test_moduli():
+    vp = np.linspace(0.8, 1.2, 11) * 3500.0
+    vs = np.linspace(0.8, 1.2, 11) * 1200.0
+    rho = np.ones(11) * 2650.0
+    k, mu = moduli(vp, vs, rho)
+    k_ref = np.array(
+        [
+            17.51968,
+            19.3154472,
+            21.1988128,
+            23.1697768,
+            25.2283392,
+            27.3745,
+            29.6082592,
+            31.9296168,
+            34.3385728,
+            36.8351272,
+            39.41928,
+        ]
+    )
+    mu_ref = np.array(
+        [
+            2.44224,
+            2.6925696,
+            2.9551104,
+            3.2298624,
+            3.5168256,
+            3.816,
+            4.1273856,
+            4.4509824,
+            4.7867904,
+            5.1348096,
+            5.49504,
+        ]
+    )
+    np.testing.assert_almost_equal(k / 1.0e9, k_ref)
+    np.testing.assert_almost_equal(mu / 1.0e9, mu_ref)
+
+
+def test_velocity():
+    rho = np.ones(11) * 2650.0
+    k = (
+        np.array(
             [
                 17.51968,
                 19.3154472,
@@ -26,7 +62,10 @@ class TestModuliVelocity:
                 39.41928,
             ]
         )
-        mu_ref = np.array(
+        * 1.0e9
+    )
+    mu = (
+        np.array(
             [
                 2.44224,
                 2.6925696,
@@ -41,64 +80,26 @@ class TestModuliVelocity:
                 5.49504,
             ]
         )
-        np.testing.assert_almost_equal(k / 1.0e9, k_ref)
-        np.testing.assert_almost_equal(mu / 1.0e9, mu_ref)
+        * 1.0e9
+    )
+    vp, vs, ai, vp_vs = velocity(k, mu, rho)
+    vp_ref = np.linspace(0.8, 1.2, 11) * 3500.0
+    vs_ref = np.linspace(0.8, 1.2, 11) * 1200.0
+    ai_ref = rho * vp
+    vp_vs_ref = vp / vs
+    np.testing.assert_almost_equal(vp, vp_ref)
+    np.testing.assert_almost_equal(vs, vs_ref)
+    np.testing.assert_almost_equal(ai, ai_ref)
+    np.testing.assert_almost_equal(vp_vs, vp_vs_ref)
 
-    def test_velocity(self):
-        rho = np.ones(11) * 2650.0
-        k = (
-            np.array(
-                [
-                    17.51968,
-                    19.3154472,
-                    21.1988128,
-                    23.1697768,
-                    25.2283392,
-                    27.3745,
-                    29.6082592,
-                    31.9296168,
-                    34.3385728,
-                    36.8351272,
-                    39.41928,
-                ]
-            )
-            * 1.0e9
-        )
-        mu = (
-            np.array(
-                [
-                    2.44224,
-                    2.6925696,
-                    2.9551104,
-                    3.2298624,
-                    3.5168256,
-                    3.816,
-                    4.1273856,
-                    4.4509824,
-                    4.7867904,
-                    5.1348096,
-                    5.49504,
-                ]
-            )
-            * 1.0e9
-        )
-        vp, vs, ai, vp_vs = velocity(k, mu, rho)
-        vp_ref = np.linspace(0.8, 1.2, 11) * 3500.0
-        vs_ref = np.linspace(0.8, 1.2, 11) * 1200.0
-        ai_ref = rho * vp
-        vp_vs_ref = vp / vs
-        np.testing.assert_almost_equal(vp, vp_ref)
-        np.testing.assert_almost_equal(vs, vs_ref)
-        np.testing.assert_almost_equal(ai, ai_ref)
-        np.testing.assert_almost_equal(vp_vs, vp_vs_ref)
 
-    def test_velocity_zero_shear_modulus_no_warning(self):
-        """Newtonian fluids have mu=0, giving vs=0. vp/vs should not raise a RuntimeWarning."""
-        k = np.array([2.2e9])
-        mu = np.array([0.0])
-        rho = np.array([1000.0])
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", RuntimeWarning)
-            _vp, vs, _ai, vp_vs = velocity(k, mu, rho)
-        np.testing.assert_almost_equal(vs, [0.0])
-        assert np.isinf(vp_vs[0])
+def test_velocity_zero_shear_modulus_no_warning():
+    """Newtonian fluids have mu=0, giving vs=0. vp/vs should not raise a RuntimeWarning."""
+    k = np.array([2.2e9])
+    mu = np.array([0.0])
+    rho = np.array([1000.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        _vp, vs, _ai, vp_vs = velocity(k, mu, rho)
+    np.testing.assert_almost_equal(vs, [0.0])
+    assert np.isinf(vp_vs[0])

--- a/tests/std_functions_tests/test_reflectivity.py
+++ b/tests/std_functions_tests/test_reflectivity.py
@@ -11,41 +11,41 @@ theta = np.ones(11)
 k = 1.9
 
 
-class TestReflectivity:
-    def test_aki_richards(self):
-        r_aki_rich = aki_richards(vp, vs, rho, theta, k=2.0)
-        r_aki_rich_ref = np.array(
-            [
-                0.0048749,
-                0.0206719,
-                -0.0025819,
-                -0.015988,
-                -0.0030281,
-                0.0119779,
-                -0.0165907,
-                0.023673,
-                0.0103467,
-                -0.0293775,
-                -0.0293775,
-            ]
-        )
-        np.testing.assert_almost_equal(r_aki_rich, r_aki_rich_ref)
+def test_aki_richards():
+    r_aki_rich = aki_richards(vp, vs, rho, theta, k=2.0)
+    r_aki_rich_ref = np.array(
+        [
+            0.0048749,
+            0.0206719,
+            -0.0025819,
+            -0.015988,
+            -0.0030281,
+            0.0119779,
+            -0.0165907,
+            0.023673,
+            0.0103467,
+            -0.0293775,
+            -0.0293775,
+        ]
+    )
+    np.testing.assert_almost_equal(r_aki_rich, r_aki_rich_ref)
 
-    def test_smith_gidlow(self):
-        r_sm_gi = smith_gidlow(vp, vs, rho, theta, k=2.0)
-        r_sm_gi_ref = np.array(
-            [
-                0.0053144,
-                0.027062,
-                -0.0066175,
-                -0.0161272,
-                -0.0033894,
-                0.0152015,
-                -0.0238758,
-                0.0280036,
-                0.0144885,
-                -0.038749,
-                -0.038749,
-            ]
-        )
-        np.testing.assert_almost_equal(r_sm_gi, r_sm_gi_ref)
+
+def test_smith_gidlow():
+    r_sm_gi = smith_gidlow(vp, vs, rho, theta, k=2.0)
+    r_sm_gi_ref = np.array(
+        [
+            0.0053144,
+            0.027062,
+            -0.0066175,
+            -0.0161272,
+            -0.0033894,
+            0.0152015,
+            -0.0238758,
+            0.0280036,
+            0.0144885,
+            -0.038749,
+            -0.038749,
+        ]
+    )
+    np.testing.assert_almost_equal(r_sm_gi, r_sm_gi_ref)

--- a/tests/std_functions_tests/test_rho.py
+++ b/tests/std_functions_tests/test_rho.py
@@ -4,44 +4,45 @@ import pytest
 from rock_physics_open.equinor_utilities.std_functions import rho_b, rho_m
 
 
-class TestRho:
-    def test_rhob(self):
-        phi = np.linspace(0.0, 0.25, 10)
-        rho_fluid = 1000 * np.ones_like(phi)
-        rho_matrix = 3000 * np.ones_like(phi)
+def test_rhob():
+    phi = np.linspace(0.0, 0.25, 10)
+    rho_fluid = 1000 * np.ones_like(phi)
+    rho_matrix = 3000 * np.ones_like(phi)
 
-        rhob = rho_b(phi, rho_fluid, rho_matrix)
-        np.testing.assert_almost_equal(rhob, np.linspace(3000, 2500, 10))
+    rhob = rho_b(phi, rho_fluid, rho_matrix)
+    np.testing.assert_almost_equal(rhob, np.linspace(3000, 2500, 10))
 
-    def test_rhom(self):
-        phi = np.linspace(0.0, 0.25, 10)
-        rho_cem = 2000 * np.ones_like(phi)
-        rho_min = 3000 * np.ones_like(phi)
-        frac_cem = 0.05 * np.ones_like(phi)
 
-        rho_mat = rho_m(frac_cem, phi, rho_cem, rho_min)
-        rho_expected = np.array(
-            [
-                2950.0,
-                2948.5714286,
-                2947.0588235,
-                2945.4545455,
-                2943.75,
-                2941.9354839,
-                2940.0,
-                2937.9310345,
-                2935.7142857,
-                2933.3333333,
-            ]
-        )
-        np.testing.assert_almost_equal(rho_mat, rho_expected)
+def test_rhom():
+    phi = np.linspace(0.0, 0.25, 10)
+    rho_cem = 2000 * np.ones_like(phi)
+    rho_min = 3000 * np.ones_like(phi)
+    frac_cem = 0.05 * np.ones_like(phi)
 
-    def test_phi_one(self):
-        phi = np.array([1.0])
-        rho_cem = 2000 * np.ones_like(phi)
-        rho_min = 3000 * np.ones_like(phi)
-        frac_cem = 0.05 * np.ones_like(phi)
+    rho_mat = rho_m(frac_cem, phi, rho_cem, rho_min)
+    rho_expected = np.array(
+        [
+            2950.0,
+            2948.5714286,
+            2947.0588235,
+            2945.4545455,
+            2943.75,
+            2941.9354839,
+            2940.0,
+            2937.9310345,
+            2935.7142857,
+            2933.3333333,
+        ]
+    )
+    np.testing.assert_almost_equal(rho_mat, rho_expected)
 
-        with pytest.warns(UserWarning, match="phi out of range in 1 sample"):
-            r_m = rho_m(frac_cem, phi, rho_cem, rho_min)
-        assert np.isnan(r_m[0])
+
+def test_phi_one():
+    phi = np.array([1.0])
+    rho_cem = 2000 * np.ones_like(phi)
+    rho_min = 3000 * np.ones_like(phi)
+    frac_cem = 0.05 * np.ones_like(phi)
+
+    with pytest.warns(UserWarning, match="phi out of range in 1 sample"):
+        r_m = rho_m(frac_cem, phi, rho_cem, rho_min)
+    assert np.isnan(r_m[0])

--- a/tests/std_functions_tests/test_voigt_reuss_hill.py
+++ b/tests/std_functions_tests/test_voigt_reuss_hill.py
@@ -14,119 +14,121 @@ mu2 = np.ones(11) * 32.0e9
 f1 = np.linspace(0, 1, 11)
 
 
-class TestVoigtReussHill:
-    def test_voigt(self):
-        k_v, mu_v = voigt(k1, mu1, k2, mu2, f1)
-        k_v_ref = np.array(
-            [71.0, 67.56, 64.12, 60.68, 57.24, 53.8, 50.36, 46.92, 43.48, 40.04, 36.6]
-        )
-        mu_v_ref = np.array(
-            [32.0, 33.2, 34.4, 35.6, 36.8, 38.0, 39.2, 40.4, 41.6, 42.8, 44.0]
-        )
-        np.testing.assert_almost_equal(k_v / 1.0e9, k_v_ref)
-        np.testing.assert_almost_equal(mu_v / 1.0e9, mu_v_ref)
+def test_voigt():
+    k_v, mu_v = voigt(k1, mu1, k2, mu2, f1)
+    k_v_ref = np.array(
+        [71.0, 67.56, 64.12, 60.68, 57.24, 53.8, 50.36, 46.92, 43.48, 40.04, 36.6]
+    )
+    mu_v_ref = np.array(
+        [32.0, 33.2, 34.4, 35.6, 36.8, 38.0, 39.2, 40.4, 41.6, 42.8, 44.0]
+    )
+    np.testing.assert_almost_equal(k_v / 1.0e9, k_v_ref)
+    np.testing.assert_almost_equal(mu_v / 1.0e9, mu_v_ref)
 
-    def test_reuss(self):
-        k_r, mu_r = reuss(k1, mu1, k2, mu2, f1)
-        k_r_ref = np.array(
-            [
-                71.0,
-                64.9000999,
-                59.7654094,
-                55.3836317,
-                51.6004766,
-                48.3011152,
-                45.3983229,
-                42.8246539,
-                40.5271366,
-                38.4635879,
-                36.6,
-            ]
-        )
-        mu_r_ref = np.array(
-            [
-                32.0,
-                32.8971963,
-                33.8461538,
-                34.8514851,
-                35.9183673,
-                37.0526316,
-                38.2608696,
-                39.5505618,
-                40.9302326,
-                42.4096386,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_r / 1.0e9, k_r_ref)
-        np.testing.assert_almost_equal(mu_r / 1.0e9, mu_r_ref)
 
-    def test_voigt_reuss_hill(self):
-        k_vrh, mu_vrh = voigt_reuss_hill(k1, mu1, k2, mu2, f1)
-        k_vrh_ref = np.array(
-            [
-                71.0,
-                66.23005,
-                61.9427047,
-                58.0318159,
-                54.4202383,
-                51.0505576,
-                47.8791614,
-                44.872327,
-                42.0035683,
-                39.251794,
-                36.6,
-            ]
-        )
-        mu_vrh_ref = np.array(
-            [
-                32.0,
-                33.0485981,
-                34.1230769,
-                35.2257426,
-                36.3591837,
-                37.5263158,
-                38.7304348,
-                39.9752809,
-                41.2651163,
-                42.6048193,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_vrh / 1.0e9, k_vrh_ref)
-        np.testing.assert_almost_equal(mu_vrh / 1.0e9, mu_vrh_ref)
+def test_reuss():
+    k_r, mu_r = reuss(k1, mu1, k2, mu2, f1)
+    k_r_ref = np.array(
+        [
+            71.0,
+            64.9000999,
+            59.7654094,
+            55.3836317,
+            51.6004766,
+            48.3011152,
+            45.3983229,
+            42.8246539,
+            40.5271366,
+            38.4635879,
+            36.6,
+        ]
+    )
+    mu_r_ref = np.array(
+        [
+            32.0,
+            32.8971963,
+            33.8461538,
+            34.8514851,
+            35.9183673,
+            37.0526316,
+            38.2608696,
+            39.5505618,
+            40.9302326,
+            42.4096386,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_r / 1.0e9, k_r_ref)
+    np.testing.assert_almost_equal(mu_r / 1.0e9, mu_r_ref)
 
-    def test_multi_voigt_reuss_hill(self):
-        k_m_vrh, mu_m_vrh = multi_voigt_reuss_hill(k1, mu1, f1, k2, mu2, 1.0 - f1)
-        k_m_vrh_ref = np.array(
-            [
-                71.0,
-                66.23005,
-                61.9427047,
-                58.0318159,
-                54.4202383,
-                51.0505576,
-                47.8791614,
-                44.872327,
-                42.0035683,
-                39.251794,
-                36.6,
-            ]
-        )
-        mu_m_vrh_ref = np.array(
-            [
-                32.0,
-                33.0485981,
-                34.1230769,
-                35.2257426,
-                36.3591837,
-                37.5263158,
-                38.7304348,
-                39.9752809,
-                41.2651163,
-                42.6048193,
-                44.0,
-            ]
-        )
-        np.testing.assert_almost_equal(k_m_vrh / 1.0e9, k_m_vrh_ref)
-        np.testing.assert_almost_equal(mu_m_vrh / 1.0e9, mu_m_vrh_ref)
+
+def test_voigt_reuss_hill():
+    k_vrh, mu_vrh = voigt_reuss_hill(k1, mu1, k2, mu2, f1)
+    k_vrh_ref = np.array(
+        [
+            71.0,
+            66.23005,
+            61.9427047,
+            58.0318159,
+            54.4202383,
+            51.0505576,
+            47.8791614,
+            44.872327,
+            42.0035683,
+            39.251794,
+            36.6,
+        ]
+    )
+    mu_vrh_ref = np.array(
+        [
+            32.0,
+            33.0485981,
+            34.1230769,
+            35.2257426,
+            36.3591837,
+            37.5263158,
+            38.7304348,
+            39.9752809,
+            41.2651163,
+            42.6048193,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_vrh / 1.0e9, k_vrh_ref)
+    np.testing.assert_almost_equal(mu_vrh / 1.0e9, mu_vrh_ref)
+
+
+def test_multi_voigt_reuss_hill():
+    k_m_vrh, mu_m_vrh = multi_voigt_reuss_hill(k1, mu1, f1, k2, mu2, 1.0 - f1)
+    k_m_vrh_ref = np.array(
+        [
+            71.0,
+            66.23005,
+            61.9427047,
+            58.0318159,
+            54.4202383,
+            51.0505576,
+            47.8791614,
+            44.872327,
+            42.0035683,
+            39.251794,
+            36.6,
+        ]
+    )
+    mu_m_vrh_ref = np.array(
+        [
+            32.0,
+            33.0485981,
+            34.1230769,
+            35.2257426,
+            36.3591837,
+            37.5263158,
+            38.7304348,
+            39.9752809,
+            41.2651163,
+            42.6048193,
+            44.0,
+        ]
+    )
+    np.testing.assert_almost_equal(k_m_vrh / 1.0e9, k_m_vrh_ref)
+    np.testing.assert_almost_equal(mu_m_vrh / 1.0e9, mu_m_vrh_ref)

--- a/tests/std_functions_tests/test_walton.py
+++ b/tests/std_functions_tests/test_walton.py
@@ -3,82 +3,82 @@ import numpy as np
 from rock_physics_open.equinor_utilities.std_functions import walton_smooth
 
 
-class TestWalton:
-    def test_walton_smooth(self):
-        k = np.ones(11) * 36.8e9
-        mu = np.ones(11) * 44.0e9
-        phi = np.linspace(0.1, 0.36, 11)
-        p_eff = np.ones(11) * 15.0e6
-        k_dry, mu_dry = walton_smooth(k, mu, phi, p_eff)
-        k_dry_ref = np.array(
-            [
-                3.6200601,
-                3.4159233,
-                3.2186296,
-                3.0281776,
-                2.8445654,
-                2.6677899,
-                2.4978473,
-                2.3347321,
-                2.1784371,
-                2.0289527,
-                1.8862663,
-            ]
-        )
-        mu_dry_ref = np.array(
-            [
-                2.172036,
-                2.049554,
-                1.9311778,
-                1.8169066,
-                1.7067392,
-                1.6006739,
-                1.4987084,
-                1.4008393,
-                1.3070623,
-                1.2173716,
-                1.1317598,
-            ]
-        )
-        np.testing.assert_almost_equal(k_dry / 1.0e9, k_dry_ref)
-        np.testing.assert_almost_equal(mu_dry / 1.0e9, mu_dry_ref)
+def test_walton_smooth():
+    k = np.ones(11) * 36.8e9
+    mu = np.ones(11) * 44.0e9
+    phi = np.linspace(0.1, 0.36, 11)
+    p_eff = np.ones(11) * 15.0e6
+    k_dry, mu_dry = walton_smooth(k, mu, phi, p_eff)
+    k_dry_ref = np.array(
+        [
+            3.6200601,
+            3.4159233,
+            3.2186296,
+            3.0281776,
+            2.8445654,
+            2.6677899,
+            2.4978473,
+            2.3347321,
+            2.1784371,
+            2.0289527,
+            1.8862663,
+        ]
+    )
+    mu_dry_ref = np.array(
+        [
+            2.172036,
+            2.049554,
+            1.9311778,
+            1.8169066,
+            1.7067392,
+            1.6006739,
+            1.4987084,
+            1.4008393,
+            1.3070623,
+            1.2173716,
+            1.1317598,
+        ]
+    )
+    np.testing.assert_almost_equal(k_dry / 1.0e9, k_dry_ref)
+    np.testing.assert_almost_equal(mu_dry / 1.0e9, mu_dry_ref)
 
-    def test_walton_smooth_n(self):
-        k = np.ones(11) * 36.8e9
-        mu = np.ones(11) * 44.0e9
-        phi = np.linspace(0.1, 0.36, 11)
-        p_eff = np.ones(11) * 15.0e6
-        n = 8.5
-        k_dry, mu_dry = walton_smooth(k, mu, phi, p_eff, coord=n)
-        k_dry_ref = np.array(
-            [
-                2.2321254,
-                2.1889267,
-                2.1452973,
-                2.1012197,
-                2.0566748,
-                2.0116422,
-                1.9660997,
-                1.9200235,
-                1.8733876,
-                1.8261639,
-                1.7783213,
-            ]
-        )
-        mu_dry_ref = np.array(
-            [
-                1.3392753,
-                1.313356,
-                1.2871784,
-                1.2607318,
-                1.2340049,
-                1.2069853,
-                1.1796598,
-                1.1520141,
-                1.1240326,
-                1.0956983,
-                1.0669928,
-            ]
-        )
-        np.testing.assert_almost_equal(k_dry / 1.0e9, k_dry_ref)
-        np.testing.assert_almost_equal(mu_dry / 1.0e9, mu_dry_ref)
+
+def test_walton_smooth_n():
+    k = np.ones(11) * 36.8e9
+    mu = np.ones(11) * 44.0e9
+    phi = np.linspace(0.1, 0.36, 11)
+    p_eff = np.ones(11) * 15.0e6
+    n = 8.5
+    k_dry, mu_dry = walton_smooth(k, mu, phi, p_eff, coord=n)
+    k_dry_ref = np.array(
+        [
+            2.2321254,
+            2.1889267,
+            2.1452973,
+            2.1012197,
+            2.0566748,
+            2.0116422,
+            1.9660997,
+            1.9200235,
+            1.8733876,
+            1.8261639,
+            1.7783213,
+        ]
+    )
+    mu_dry_ref = np.array(
+        [
+            1.3392753,
+            1.313356,
+            1.2871784,
+            1.2607318,
+            1.2340049,
+            1.2069853,
+            1.1796598,
+            1.1520141,
+            1.1240326,
+            1.0956983,
+            1.0669928,
+        ]
+    )
+    np.testing.assert_almost_equal(k_dry / 1.0e9, k_dry_ref)
+    np.testing.assert_almost_equal(mu_dry / 1.0e9, mu_dry_ref)

--- a/tests/std_functions_tests/test_wood_brie.py
+++ b/tests/std_functions_tests/test_wood_brie.py
@@ -1,112 +1,106 @@
-from typing import final
-
 import numpy as np
 from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.std_functions import brie, multi_wood, wood
 
-
-class TestWoodBrie:
-    def setup(self):
-        s_gas = np.array([1.0, 0.0, 0.0])
-        s_brine = np.array([0.0, 1.0, 0.0])
-        s_oil = np.array([0.0, 0.0, 1.0])
-        k_gas = np.array([0.25e6, 0.25e6, 0.25e6])
-        k_brine = np.array([2.8e9, 2.8e9, 2.8e9])
-        k_oil = np.array([0.9e9, 0.9e9, 0.9e9])
-        rho_gas = np.array([210, 210, 210])
-        rho_brine = np.array([1005, 1005, 1005])
-
-        return s_gas, s_brine, s_oil, k_gas, k_brine, k_oil, rho_gas, rho_brine
-
-    def test_wood(self):
-        s_gas, _, _, k_gas, k_brine, _, rho_gas, rho_brine = self.setup()
-        k, rho = wood(s_gas, k_gas, rho_gas, k_brine, rho_brine)
-        k_ref = np.array([0.25e6, 2.8e9, 2.8e9])
-        rho_ref = np.array([210, 1005, 1005])
-        np.testing.assert_almost_equal(k, k_ref)
-        np.testing.assert_almost_equal(rho, rho_ref)
-
-    def test_brie(self):
-        s_gas, s_brine, s_oil, k_gas, k_brine, k_oil, _, _ = self.setup()
-        e = 1.5
-        k = brie(s_gas, k_gas, s_brine, k_brine, s_oil, k_oil, e)
-        k_ref = np.array([0.25e6, 2.8e9, 0.9e9])
-        np.testing.assert_almost_equal(k, k_ref)
-
-    def test_wood_brie_mix(self):
-        rg = default_rng(12345)
-        s_gas = 0.5 * rg.random(11)
-        s_oil = 0.5 * rg.random(11)
-        s_brine = 1.0 - (s_gas + s_oil)
-        k_gas = 0.25e6 * np.ones_like(s_gas)
-        k_brine = 2.8e9 * np.ones_like(s_gas)
-        k_oil = 0.9e9 * np.ones_like(s_gas)
-        e = 1.7
-        k_w = wood(s_gas, k_gas, np.ones_like(s_gas), k_brine, np.ones_like(s_gas))[0]
-        k_b = brie(s_gas, k_gas, s_brine, k_brine, s_oil, k_oil, e)
-        k_w_ref = np.array(
-            [
-                2197857.3032863,
-                1577741.8284602,
-                626980.6039708,
-                739237.2282665,
-                1277944.8143517,
-                1501669.3287616,
-                835514.1581449,
-                2675283.4430605,
-                743080.5661045,
-                530843.4103878,
-                2012865.2583938,
-            ]
-        )
-        k_b_ref = np.array(
-            [
-                1.2081004,
-                1.3510999,
-                1.6787997,
-                1.2305812,
-                1.111577,
-                1.3090595,
-                1.4636728,
-                1.4097729,
-                1.5565275,
-                1.5423466,
-                2.1396782,
-            ]
-        )
-        np.testing.assert_almost_equal(k_w, k_w_ref)
-        np.testing.assert_almost_equal(k_b / 1e9, k_b_ref)
+s_gas = np.array([1.0, 0.0, 0.0])
+s_brine = np.array([0.0, 1.0, 0.0])
+s_oil = np.array([0.0, 0.0, 1.0])
+k_gas = np.array([0.25e6, 0.25e6, 0.25e6])
+k_brine = np.array([2.8e9, 2.8e9, 2.8e9])
+k_oil = np.array([0.9e9, 0.9e9, 0.9e9])
+rho_gas = np.array([210, 210, 210])
+rho_brine = np.array([1005, 1005, 1005])
 
 
-@final
-class TestMultiWood:
-    s_gi = 0.0
-    s_oi = 0.5
-    s_wi = 0.5
-    oil_init_k = 492_032_461.8739312
-    gas_init_k = 208_287_817.8755032
-    brine_init_k = 2_814_732_817.889945
-    expected_value = 837_640_292.3902907
+def test_wood():
+    k, rho = wood(s_gas, k_gas, rho_gas, k_brine, rho_brine)
+    k_ref = np.array([0.25e6, 2.8e9, 2.8e9])
+    rho_ref = np.array([210, 1005, 1005])
+    np.testing.assert_almost_equal(k, k_ref)
+    np.testing.assert_almost_equal(rho, rho_ref)
 
-    def test_multi_wood_array(self):
-        """Test multi_wood with numpy array inputs."""
-        result = multi_wood(
-            fractions=[np.array(self.s_oi), np.array(self.s_gi), np.array(self.s_wi)],
-            bulk_moduli=[
-                np.array(self.oil_init_k),
-                np.array(self.gas_init_k),
-                np.array(self.brine_init_k),
-            ],
-        )
-        expected = np.array([self.expected_value])
-        np.testing.assert_almost_equal(result, expected)
 
-    def test_multi_wood_scalar(self):
-        """Test multi_wood with scalar inputs."""
-        result = multi_wood(
-            fractions=[self.s_oi, self.s_gi, self.s_wi],
-            bulk_moduli=[self.oil_init_k, self.gas_init_k, self.brine_init_k],
-        )
-        expected = self.expected_value
-        np.testing.assert_almost_equal(result, expected)
+def test_brie():
+    e = 1.5
+    k = brie(s_gas, k_gas, s_brine, k_brine, s_oil, k_oil, e)
+    k_ref = np.array([0.25e6, 2.8e9, 0.9e9])
+    np.testing.assert_almost_equal(k, k_ref)
+
+
+def test_wood_brie_mix():
+    rg = default_rng(12345)
+    s_gas = 0.5 * rg.random(11)
+    s_oil = 0.5 * rg.random(11)
+    s_brine = 1.0 - (s_gas + s_oil)
+    k_gas = 0.25e6 * np.ones_like(s_gas)
+    k_brine = 2.8e9 * np.ones_like(s_gas)
+    k_oil = 0.9e9 * np.ones_like(s_gas)
+    e = 1.7
+    k_w = wood(s_gas, k_gas, np.ones_like(s_gas), k_brine, np.ones_like(s_gas))[0]
+    k_b = brie(s_gas, k_gas, s_brine, k_brine, s_oil, k_oil, e)
+    k_w_ref = np.array(
+        [
+            2197857.3032863,
+            1577741.8284602,
+            626980.6039708,
+            739237.2282665,
+            1277944.8143517,
+            1501669.3287616,
+            835514.1581449,
+            2675283.4430605,
+            743080.5661045,
+            530843.4103878,
+            2012865.2583938,
+        ]
+    )
+    k_b_ref = np.array(
+        [
+            1.2081004,
+            1.3510999,
+            1.6787997,
+            1.2305812,
+            1.111577,
+            1.3090595,
+            1.4636728,
+            1.4097729,
+            1.5565275,
+            1.5423466,
+            2.1396782,
+        ]
+    )
+    np.testing.assert_almost_equal(k_w, k_w_ref)
+    np.testing.assert_almost_equal(k_b / 1e9, k_b_ref)
+
+
+s_gi = 0.0
+s_oi = 0.5
+s_wi = 0.5
+oil_init_k = 492_032_461.8739312
+gas_init_k = 208_287_817.8755032
+brine_init_k = 2_814_732_817.889945
+expected_value = 837_640_292.3902907
+
+
+def test_multi_wood_array():
+    """Test multi_wood with numpy array inputs."""
+    result = multi_wood(
+        fractions=[np.array(s_oi), np.array(s_gi), np.array(s_wi)],
+        bulk_moduli=[
+            np.array(oil_init_k),
+            np.array(gas_init_k),
+            np.array(brine_init_k),
+        ],
+    )
+    expected = np.array([expected_value])
+    np.testing.assert_almost_equal(result, expected)
+
+
+def test_multi_wood_scalar():
+    """Test multi_wood with scalar inputs."""
+    result = multi_wood(
+        fractions=[s_oi, s_gi, s_wi],
+        bulk_moduli=[oil_init_k, gas_init_k, brine_init_k],
+    )
+    expected = expected_value
+    np.testing.assert_almost_equal(result, expected)

--- a/tests/various_utilities_tests/test_hs_average.py
+++ b/tests/various_utilities_tests/test_hs_average.py
@@ -4,44 +4,43 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.various_utilities import hs_average
 
 
-class TestHS:
-    def test_hashin_shtrikman_average(self):
-        rg = default_rng(42)
-        f = rg.random(10)
-        k1 = 36.8e9 * np.ones_like(f)
-        mu1 = 44.0e9 * np.ones_like(f)
-        rho1 = 2650.0 * np.ones_like(f)
-        k2 = 71.2e9 * np.ones_like(f)
-        mu2 = 32.0e9 * np.ones_like(f)
-        rho2 = 2710.0 * np.ones_like(f)
-        vp, vs = hs_average(k1, mu1, rho1, k2, mu2, rho2, f)[0:2]
-        vp_ref = np.array(
-            [
-                6045.198023,
-                6174.5154768,
-                6025.1116175,
-                6067.5931606,
-                6401.1173579,
-                6005.143869,
-                6048.6629321,
-                6042.0277693,
-                6374.082277,
-                6168.6768996,
-            ]
-        )
-        vs_ref = np.array(
-            [
-                3920.4844507,
-                3703.175796,
-                3977.4848829,
-                3869.6688652,
-                3492.0335032,
-                4057.8105084,
-                3911.9312645,
-                3928.5836574,
-                3512.3142984,
-                3710.4311108,
-            ]
-        )
-        np.testing.assert_almost_equal(vp, vp_ref)
-        np.testing.assert_almost_equal(vs, vs_ref)
+def test_hashin_shtrikman_average():
+    rg = default_rng(42)
+    f = rg.random(10)
+    k1 = 36.8e9 * np.ones_like(f)
+    mu1 = 44.0e9 * np.ones_like(f)
+    rho1 = 2650.0 * np.ones_like(f)
+    k2 = 71.2e9 * np.ones_like(f)
+    mu2 = 32.0e9 * np.ones_like(f)
+    rho2 = 2710.0 * np.ones_like(f)
+    vp, vs = hs_average(k1, mu1, rho1, k2, mu2, rho2, f)[0:2]
+    vp_ref = np.array(
+        [
+            6045.198023,
+            6174.5154768,
+            6025.1116175,
+            6067.5931606,
+            6401.1173579,
+            6005.143869,
+            6048.6629321,
+            6042.0277693,
+            6374.082277,
+            6168.6768996,
+        ]
+    )
+    vs_ref = np.array(
+        [
+            3920.4844507,
+            3703.175796,
+            3977.4848829,
+            3869.6688652,
+            3492.0335032,
+            4057.8105084,
+            3911.9312645,
+            3928.5836574,
+            3512.3142984,
+            3710.4311108,
+        ]
+    )
+    np.testing.assert_almost_equal(vp, vp_ref)
+    np.testing.assert_almost_equal(vs, vs_ref)

--- a/tests/various_utilities_tests/test_pressure.py
+++ b/tests/various_utilities_tests/test_pressure.py
@@ -4,90 +4,90 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.various_utilities import pressure
 
 
-class TestPressure:
-    def test_pressure(self):
-        rg = default_rng(987654321)
-        rho = 2650 * (0.8 + 0.2 * rg.random(11))
-        tvd_msl = np.linspace(2200, 2500, 11)
-        water_depth = 240.0
-        p_form = 20.0e6
-        tvd_p_form = 2300.0
-        n = 0.89
-        p_eff, p_lith = pressure(rho, tvd_msl, water_depth, p_form, tvd_p_form, n)
-        p_eff_ref = np.array(
-            [
-                26965839.7074737,
-                27378582.1519758,
-                27791324.5964779,
-                28204067.0409801,
-                28341647.8558141,
-                28341647.8558141,
-                28341647.8558141,
-                28341647.8558141,
-                28341647.8558141,
-                28341647.8558141,
-                28341647.8558141,
-            ]
-        )
-        p_lith_ref = np.array(
-            [
-                44156462.2597103,
-                44806963.6761548,
-                45461677.0549971,
-                46141647.8558141,
-                46788318.3400473,
-                47456762.5944036,
-                48138689.8657396,
-                48778246.1823415,
-                49432568.3607947,
-                50158507.0041808,
-                50806835.7838177,
-            ]
-        )
-        np.testing.assert_almost_equal(p_lith, p_lith_ref)
-        np.testing.assert_almost_equal(p_eff, p_eff_ref)
+def test_pressure():
+    rg = default_rng(987654321)
+    rho = 2650 * (0.8 + 0.2 * rg.random(11))
+    tvd_msl = np.linspace(2200, 2500, 11)
+    water_depth = 240.0
+    p_form = 20.0e6
+    tvd_p_form = 2300.0
+    n = 0.89
+    p_eff, p_lith = pressure(rho, tvd_msl, water_depth, p_form, tvd_p_form, n)
+    p_eff_ref = np.array(
+        [
+            26965839.7074737,
+            27378582.1519758,
+            27791324.5964779,
+            28204067.0409801,
+            28341647.8558141,
+            28341647.8558141,
+            28341647.8558141,
+            28341647.8558141,
+            28341647.8558141,
+            28341647.8558141,
+            28341647.8558141,
+        ]
+    )
+    p_lith_ref = np.array(
+        [
+            44156462.2597103,
+            44806963.6761548,
+            45461677.0549971,
+            46141647.8558141,
+            46788318.3400473,
+            47456762.5944036,
+            48138689.8657396,
+            48778246.1823415,
+            49432568.3607947,
+            50158507.0041808,
+            50806835.7838177,
+        ]
+    )
+    np.testing.assert_almost_equal(p_lith, p_lith_ref)
+    np.testing.assert_almost_equal(p_eff, p_eff_ref)
 
-    def test_pressure_inf_nan(self):
-        rg = default_rng(987654321)
-        rho = 2650 * (0.8 + 0.2 * rg.random(11))
-        rho[4] = np.nan
-        rho[7] = np.inf
-        tvd_msl = np.linspace(2200, 2500, 11)
-        tvd_msl[2] = np.nan
-        water_depth = 240.0
-        p_form = 20.0e6
-        tvd_p_form = 2300.0
-        n = 0.89
-        p_eff, p_lith = pressure(rho, tvd_msl, water_depth, p_form, tvd_p_form, n)
-        p_eff_ref = np.array(
-            [
-                27608794.7187852,
-                28031378.3114197,
-                np.nan,
-                28876545.4966886,
-                np.nan,
-                29017406.6942335,
-                29017406.6942335,
-                np.nan,
-                29017406.6942335,
-                29017406.6942335,
-                29017406.6942335,
-            ]
-        )
-        p_lith_ref = np.array(
-            [
-                44156462.2597103,
-                45457465.0925993,
-                np.nan,
-                46817406.6942335,
-                np.nan,
-                47485850.9485897,
-                48849705.4912617,
-                np.nan,
-                49504027.6697149,
-                50229966.313101,
-                50878295.0927379,
-            ]
-        )
-        np.testing.assert_almost_equal(p_lith, p_lith_ref)
-        np.testing.assert_almost_equal(p_eff, p_eff_ref)
+
+def test_pressure_inf_nan():
+    rg = default_rng(987654321)
+    rho = 2650 * (0.8 + 0.2 * rg.random(11))
+    rho[4] = np.nan
+    rho[7] = np.inf
+    tvd_msl = np.linspace(2200, 2500, 11)
+    tvd_msl[2] = np.nan
+    water_depth = 240.0
+    p_form = 20.0e6
+    tvd_p_form = 2300.0
+    n = 0.89
+    p_eff, p_lith = pressure(rho, tvd_msl, water_depth, p_form, tvd_p_form, n)
+    p_eff_ref = np.array(
+        [
+            27608794.7187852,
+            28031378.3114197,
+            np.nan,
+            28876545.4966886,
+            np.nan,
+            29017406.6942335,
+            29017406.6942335,
+            np.nan,
+            29017406.6942335,
+            29017406.6942335,
+            29017406.6942335,
+        ]
+    )
+    p_lith_ref = np.array(
+        [
+            44156462.2597103,
+            45457465.0925993,
+            np.nan,
+            46817406.6942335,
+            np.nan,
+            47485850.9485897,
+            48849705.4912617,
+            np.nan,
+            49504027.6697149,
+            50229966.313101,
+            50878295.0927379,
+        ]
+    )
+    np.testing.assert_almost_equal(p_lith, p_lith_ref)
+    np.testing.assert_almost_equal(p_eff, p_eff_ref)

--- a/tests/various_utilities_tests/test_reflectivity.py
+++ b/tests/various_utilities_tests/test_reflectivity.py
@@ -4,71 +4,66 @@ from numpy.random import default_rng
 
 from rock_physics_open.equinor_utilities.various_utilities import reflectivity
 
+rg = default_rng(5947037623874)
+vp = 3500 * (1.0 + 0.2 * rg.random(11))
+vs = 1200 * (1.0 + 0.4 * rg.random(11))
+rho = 2650 * (1.0 + 0.02 * rg.random(11))
+theta = 10.0
+k = 2.0
 
-class TestReflectivity:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        rg = default_rng(5947037623874)
-        self.vp = 3500 * (1.0 + 0.2 * rg.random(11))
-        self.vs = 1200 * (1.0 + 0.4 * rg.random(11))
-        self.rho = 2650 * (1.0 + 0.02 * rg.random(11))
-        self.theta = 10.0
-        self.k = 2.0
 
-    def test_reflectivity_AR_ok_inputs(self):
-        r_aki_rich, idx = reflectivity(
-            self.vp, self.vs, self.rho, theta=self.theta, k=self.k, model="AkiRichards"
-        )
-        r_aki_rich_ref = np.array(
-            [
-                0.006805,
-                0.0028961,
-                0.0073632,
-                -0.0016639,
-                -0.0053192,
-                -0.0114692,
-                0.0059247,
-                -0.0300648,
-                0.015451,
-                0.0143082,
-                0.0143082,
-            ]
-        )
-        idx_ref = np.ones(11).astype(bool)
-        np.testing.assert_almost_equal(r_aki_rich, r_aki_rich_ref)
-        np.testing.assert_almost_equal(idx, idx_ref)
+def test_reflectivity_AR_ok_inputs():
+    r_aki_rich, idx = reflectivity(vp, vs, rho, theta=theta, k=k, model="AkiRichards")
+    r_aki_rich_ref = np.array(
+        [
+            0.006805,
+            0.0028961,
+            0.0073632,
+            -0.0016639,
+            -0.0053192,
+            -0.0114692,
+            0.0059247,
+            -0.0300648,
+            0.015451,
+            0.0143082,
+            0.0143082,
+        ]
+    )
+    idx_ref = np.ones(11).astype(bool)
+    np.testing.assert_almost_equal(r_aki_rich, r_aki_rich_ref)
+    np.testing.assert_almost_equal(idx, idx_ref)
 
-    def test_reflectivity_SG_ok_inputs(self):
-        r_sm_gi, idx = reflectivity(
-            self.vp, self.vs, self.rho, theta=self.theta, k=self.k, model="SmithGidlow"
-        )
-        r_sm_gi_ref = np.array(
-            [
-                0.0041067,
-                0.0033311,
-                0.012066,
-                -0.0041207,
-                -0.0024095,
-                -0.0165878,
-                0.0082089,
-                -0.0389886,
-                0.0207101,
-                0.0145037,
-                0.0145037,
-            ]
-        )
-        idx_ref = np.ones(11).astype(bool)
-        np.testing.assert_almost_equal(r_sm_gi, r_sm_gi_ref)
-        np.testing.assert_almost_equal(idx, idx_ref)
 
-    def test_reflectivity_nan(self):
-        self.vp[5] = np.nan
-        with pytest.raises(ValueError, match="Missing or illegal values in input"):
-            _ = reflectivity(
-                vp_inp=self.vp,
-                vs_inp=self.vs,
-                rho_inp=self.rho,
-                theta=self.theta,
-                k=self.k,
-                model="AkiRichards",
-            )
+def test_reflectivity_SG_ok_inputs():
+    r_sm_gi, idx = reflectivity(vp, vs, rho, theta=theta, k=k, model="SmithGidlow")
+    r_sm_gi_ref = np.array(
+        [
+            0.0041067,
+            0.0033311,
+            0.012066,
+            -0.0041207,
+            -0.0024095,
+            -0.0165878,
+            0.0082089,
+            -0.0389886,
+            0.0207101,
+            0.0145037,
+            0.0145037,
+        ]
+    )
+    idx_ref = np.ones(11).astype(bool)
+    np.testing.assert_almost_equal(r_sm_gi, r_sm_gi_ref)
+    np.testing.assert_almost_equal(idx, idx_ref)
+
+
+def test_reflectivity_nan():
+    vp[5] = np.nan
+    with pytest.raises(ValueError, match="Missing or illegal values in input"):
+        _ = reflectivity(
+            vp_inp=vp,
+            vs_inp=vs,
+            rho_inp=rho,
+            theta=theta,
+            k=k,
+            model="AkiRichards",
+        )

--- a/tests/various_utilities_tests/test_time_shift.py
+++ b/tests/various_utilities_tests/test_time_shift.py
@@ -7,55 +7,55 @@ from rock_physics_open.equinor_utilities.various_utilities import (
 )
 
 
-class TestTimeShift:
-    def test_time_shift_ps(self):
-        rg = default_rng(672190547)
-        tvd = np.linspace(1900.0, 2100.0, 11)
-        vp_base = 3500.0 * (0.5 + 0.5 * rg.random(11))
-        vp_mon = 3500.0 * (0.5 + 0.5 * rg.random(11))
-        vs_base = 1700.0 * (0.5 + 0.5 * rg.random(11))
-        vs_mon = 1700.0 * (0.5 + 0.5 * rg.random(11))
-        multiplier = 1
-        twt_ps_shift = time_shift_ps(tvd, vp_base, vp_mon, vs_base, vs_mon, multiplier)
-        twt_ref = np.array(
-            [
-                -1.487565,
-                -1.8224189,
-                1.0883962,
-                0.0848656,
-                2.6961336,
-                -2.1949398,
-                -4.3835154,
-                0.2291774,
-                -6.2099461,
-                -5.7735105,
-                -9.4191945,
-            ]
-        )
-        np.testing.assert_almost_equal(twt_ps_shift, twt_ref)
+def test_time_shift_ps():
+    rg = default_rng(672190547)
+    tvd = np.linspace(1900.0, 2100.0, 11)
+    vp_base = 3500.0 * (0.5 + 0.5 * rg.random(11))
+    vp_mon = 3500.0 * (0.5 + 0.5 * rg.random(11))
+    vs_base = 1700.0 * (0.5 + 0.5 * rg.random(11))
+    vs_mon = 1700.0 * (0.5 + 0.5 * rg.random(11))
+    multiplier = 1
+    twt_ps_shift = time_shift_ps(tvd, vp_base, vp_mon, vs_base, vs_mon, multiplier)
+    twt_ref = np.array(
+        [
+            -1.487565,
+            -1.8224189,
+            1.0883962,
+            0.0848656,
+            2.6961336,
+            -2.1949398,
+            -4.3835154,
+            0.2291774,
+            -6.2099461,
+            -5.7735105,
+            -9.4191945,
+        ]
+    )
+    np.testing.assert_almost_equal(twt_ps_shift, twt_ref)
 
-    def test_time_shift_pp(self):
-        rg = default_rng(3874629384)
-        tvd = np.linspace(1900.0, 2100.0, 11)
-        vp_base = 3500.0 * (0.5 + 0.5 * rg.random(11))
-        vp_mon = 3500.0 * (0.5 + 0.5 * rg.random(11))
-        multiplier = 1
-        owt_pp_shift, twt_pp_shift = time_shift_pp(tvd, vp_base, vp_mon, multiplier)
-        owt_ref = np.array(
-            [
-                -2.389087,
-                -2.6406689,
-                -1.1021602,
-                -4.4961946,
-                -0.858652,
-                -2.7415121,
-                -5.375477,
-                -3.7926991,
-                -6.0184832,
-                -2.2550444,
-                -5.1210616,
-            ]
-        )
-        twt_ref = 2.0 * owt_ref
-        np.testing.assert_almost_equal(owt_pp_shift, owt_ref)
-        np.testing.assert_almost_equal(twt_pp_shift, twt_ref)
+
+def test_time_shift_pp():
+    rg = default_rng(3874629384)
+    tvd = np.linspace(1900.0, 2100.0, 11)
+    vp_base = 3500.0 * (0.5 + 0.5 * rg.random(11))
+    vp_mon = 3500.0 * (0.5 + 0.5 * rg.random(11))
+    multiplier = 1
+    owt_pp_shift, twt_pp_shift = time_shift_pp(tvd, vp_base, vp_mon, multiplier)
+    owt_ref = np.array(
+        [
+            -2.389087,
+            -2.6406689,
+            -1.1021602,
+            -4.4961946,
+            -0.858652,
+            -2.7415121,
+            -5.375477,
+            -3.7926991,
+            -6.0184832,
+            -2.2550444,
+            -5.1210616,
+        ]
+    )
+    twt_ref = 2.0 * owt_ref
+    np.testing.assert_almost_equal(owt_pp_shift, owt_ref)
+    np.testing.assert_almost_equal(twt_pp_shift, twt_ref)

--- a/tests/various_utilities_tests/test_vrh_3_min.py
+++ b/tests/various_utilities_tests/test_vrh_3_min.py
@@ -4,69 +4,68 @@ from numpy.random import default_rng
 from rock_physics_open.equinor_utilities.various_utilities import min_3_voigt_reuss_hill
 
 
-class TestMin3VRH:
-    def test_3_mineral_voigt_reuss_hill(self):
-        rg = default_rng(260363)
-        f1 = 0.33 * rg.random(11)
-        f2 = 0.33 * rg.random(11)
-        f3 = 0.33 * rg.random(11)
-        vp1 = 6050.0 * np.ones(11)
-        vs1 = 4090.0 * np.ones(11)
-        rho1 = 2650.0 * np.ones(11)
-        vp2 = 6640.0 * np.ones(11)
-        vs2 = 3440.0 * np.ones(11)
-        rho2 = 2710.0 * np.ones(11)
-        vp3 = 7340.0 * np.ones(11)
-        vs3 = 3960.0 * np.ones(11)
-        rho3 = 2870.0 * np.ones(11)
-        vp, vs, rho = min_3_voigt_reuss_hill(
-            vp1, vs1, rho1, f1, vp2, vs2, rho2, f2, vp3, vs3, rho3, f3
-        )[0:3]
-        vp_ref = np.array(
-            [
-                6717.9175171,
-                6800.3189303,
-                6624.4446804,
-                6750.0741773,
-                6174.0931249,
-                6464.0869351,
-                6798.4129712,
-                6495.8033624,
-                6826.4121872,
-                6573.038569,
-                6595.6224302,
-            ]
-        )
-        vs_ref = np.array(
-            [
-                3747.7259178,
-                3734.6876154,
-                3855.2166557,
-                3729.0785307,
-                4017.1020017,
-                4031.9058341,
-                3745.7727205,
-                3777.5636891,
-                3812.1757253,
-                3790.0322411,
-                3906.8306075,
-            ]
-        )
-        rho_ref = np.array(
-            [
-                2761.6394369,
-                2772.287933,
-                2756.8150973,
-                2764.3215062,
-                2676.6615413,
-                2736.3677518,
-                2773.3473826,
-                2728.3556655,
-                2785.0461618,
-                2742.6151621,
-                2755.545227,
-            ]
-        )
-        np.testing.assert_almost_equal(vp, vp_ref)
-        np.testing.assert_almost_equal(vs, vs_ref)
-        np.testing.assert_almost_equal(rho, rho_ref)
+def test_3_mineral_voigt_reuss_hill():
+    rg = default_rng(260363)
+    f1 = 0.33 * rg.random(11)
+    f2 = 0.33 * rg.random(11)
+    f3 = 0.33 * rg.random(11)
+    vp1 = 6050.0 * np.ones(11)
+    vs1 = 4090.0 * np.ones(11)
+    rho1 = 2650.0 * np.ones(11)
+    vp2 = 6640.0 * np.ones(11)
+    vs2 = 3440.0 * np.ones(11)
+    rho2 = 2710.0 * np.ones(11)
+    vp3 = 7340.0 * np.ones(11)
+    vs3 = 3960.0 * np.ones(11)
+    rho3 = 2870.0 * np.ones(11)
+    vp, vs, rho = min_3_voigt_reuss_hill(
+        vp1, vs1, rho1, f1, vp2, vs2, rho2, f2, vp3, vs3, rho3, f3
+    )[0:3]
+    vp_ref = np.array(
+        [
+            6717.9175171,
+            6800.3189303,
+            6624.4446804,
+            6750.0741773,
+            6174.0931249,
+            6464.0869351,
+            6798.4129712,
+            6495.8033624,
+            6826.4121872,
+            6573.038569,
+            6595.6224302,
+        ]
+    )
+    vs_ref = np.array(
+        [
+            3747.7259178,
+            3734.6876154,
+            3855.2166557,
+            3729.0785307,
+            4017.1020017,
+            4031.9058341,
+            3745.7727205,
+            3777.5636891,
+            3812.1757253,
+            3790.0322411,
+            3906.8306075,
+        ]
+    )
+    rho_ref = np.array(
+        [
+            2761.6394369,
+            2772.287933,
+            2756.8150973,
+            2764.3215062,
+            2676.6615413,
+            2736.3677518,
+            2773.3473826,
+            2728.3556655,
+            2785.0461618,
+            2742.6151621,
+            2755.545227,
+        ]
+    )
+    np.testing.assert_almost_equal(vp, vp_ref)
+    np.testing.assert_almost_equal(vs, vs_ref)
+    np.testing.assert_almost_equal(rho, rho_ref)


### PR DESCRIPTION
> [!TIP]
> enable "Hide whitespace" in the git diff to make this easier to review, as the majority of the changed lines in this PR are simply a removed level of indenting.
> <img width="300" alt="Screenshot 2026-04-27 at 08 26 13" src="https://github.com/user-attachments/assets/324b3745-fa88-4809-8a46-5cbdeb47b7fa" />


Purpose of this PR is to make testing easier for ourselves by sticking to a single test pattern. 

Our code and test setup is not really complex enough to really benefit from TestClasses (as seen in this diff, the classes are mostly redundant). So the current test pattern is to use plain functions, with fixtures where needed.

> [!NOTE]
> There are two improvements to the test configuration _not_ part of this PR that will also be done. But left out of this one to keep the diffs simple. Those are:
> - not define test parameters as "global" variables
>   > Done here to be consistent with existing/other tests, but should either be inline/local variables or fixtures / dataclasses.
> - use more snapshots
>   > A fair amount of the tests (including a lot of the ones updated in this PR) manually defines, or calculates the expected results, we can save ourselves a lot of code / manual work by simply using snapshots, that (now) will write ascii files with the exact expected output.