### PR TITLE
fix(classification_functions): correct dtype annotations for class IDs

### DIFF
--- a/src/rock_physics_open/equinor_utilities/classification_functions/lin_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/lin_class.py
@@ -7,9 +7,9 @@ NULL_CLASS = 0
 def lin_class(
     obs: npt.NDArray[np.float64],
     class_mean: npt.NDArray[np.float64],
-    class_id: npt.NDArray[np.float64],
+    class_id: npt.NDArray[np.int64],
     thresh: float = np.inf,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]:
     """
     Linear classification routine. All data points are assigned a class, unless a threshold is set.
 

--- a/src/rock_physics_open/equinor_utilities/classification_functions/mahal_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/mahal_class.py
@@ -12,7 +12,7 @@ def mahal_class(
     class_cov: npt.NDArray[np.float64],
     class_id: npt.NDArray[np.int64],
     thresh: float = np.inf,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
     Mahalanobis classification routine. All data points are assigned a class, unless a threshold is set.
 

--- a/src/rock_physics_open/equinor_utilities/classification_functions/norm_class.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/norm_class.py
@@ -11,7 +11,7 @@ def norm_class(
     prior_prob: npt.NDArray[np.float64],
     class_id: npt.NDArray[np.int64],
     thresh: float = np.inf,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
     Normal distribution classification routine.
 

--- a/src/rock_physics_open/equinor_utilities/classification_functions/two_step_classification.py
+++ b/src/rock_physics_open/equinor_utilities/classification_functions/two_step_classification.py
@@ -17,7 +17,7 @@ def gen_two_step_class_stats(
     npt.NDArray[np.float64],
     npt.NDArray[np.int64],
     npt.NDArray[np.int64],
-    npt.NDArray[np.float64],
+    npt.NDArray[np.int64],
 ]:
     """
     The observations are an n x m array, where n is the number of observations and m is the number of variables.


### PR DESCRIPTION
Fixes #148.

Several public functions in `rock_physics_open.equinor_utilities.classification_functions` had dtype annotations that didn't match docstrings or runtime values. This PR aligns the annotations with the actual integer class-id arrays.

Changes:
- `lin_class`: `class_id` parameter changed from `NDArray[np.float64]` → `NDArray[np.int64]` (matches docstring "integer numbers" and the other classifiers). First return element changed from `NDArray[np.float64]` → `NDArray[np.int64]`.
- `mahal_class`: first return element (`mahal_class_arr`) changed from `NDArray[np.float64]` → `NDArray[np.int64]`.
- `norm_class`: first return element (`norm_class_id`) changed from `NDArray[np.float64]` → `NDArray[np.int64]`.
- `gen_two_step_class_stats`: last return element (`mahal_class_id`) changed from `NDArray[np.float64]` → `NDArray[np.int64]`.

The `poly_class` annotations called out in the issue (against 0.6.1) were already correct on `main`.

Validation: ruff, basedpyright (0 errors), and the full pytest suite (187 passed, 70 snapshots) all pass.