### PR TITLE
fix(t_matrix_models): drop cast in calc_pressure_vec return

### DIFF
--- a/src/rock_physics_open/t_matrix_models/run_t_matrix.py
+++ b/src/rock_physics_open/t_matrix_models/run_t_matrix.py
@@ -283,11 +283,9 @@ def run_t_matrix(
             # arrays from calc_pressure_vec when their branch is skipped by
             # ctrl_connected; pick the populated alpha here.
             if ctrl_connected == 0:
-                v_con = np.zeros_like(v_iso)
                 alpha = alpha_iso
             elif ctrl_connected == 2:
                 alpha = alpha_con
-                v_iso = np.zeros_like(v_con)
             else:
                 alpha = alpha_con
             # Don't divide by zero

--- a/src/rock_physics_open/t_matrix_models/run_t_matrix.py
+++ b/src/rock_physics_open/t_matrix_models/run_t_matrix.py
@@ -279,7 +279,9 @@ def run_t_matrix(
             # As mentioned: assume that there is no distinction between alpha_con and alpha_iso, that could only
             # happen if they differed from the start
 
-            # v_con, alpha_con or v_iso, alpha_iso can be returned as None from calc_pressure_vec
+            # v_con, alpha_con or v_iso, alpha_iso are returned as zero
+            # arrays from calc_pressure_vec when their branch is skipped by
+            # ctrl_connected; pick the populated alpha here.
             if ctrl_connected == 0:
                 v_con = np.zeros_like(v_iso)
                 alpha = alpha_iso

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 
@@ -161,13 +161,16 @@ def calc_pressure_vec(
             sum_kd = sum_kd + v_con[:, j] * np.sum(
                 kd_eff_connected[:, 0:3, 0:3, j], axis=(1, 2)
             )
-    # Find the new concentration of inclusion
-    alpha_n_isolated = None
-    alpha_n_connected = None
-    v_n_isolated = None
-    v_n_connected = None
-    gamma_n_out = None
-    tau_n_out = None
+    # Find the new concentration of inclusion. Initialise outputs to zero
+    # arrays matching the input shapes so that branches skipped by ``ctrl``
+    # still satisfy the non-optional return type. Callers rely on ``ctrl`` to
+    # know which outputs are meaningful.
+    alpha_n_isolated = np.zeros_like(alpha_iso)
+    alpha_n_connected = np.zeros_like(alpha_con)
+    v_n_isolated = np.zeros_like(v_iso)
+    v_n_connected = np.zeros_like(v_con)
+    gamma_n_out = np.zeros_like(gamma)
+    tau_n_out = np.zeros_like(tau)
     if ctrl != 2 and kd_eff_isolated is not None:
         v_n_isolated, alpha_n_isolated, _, _ = _new_values(
             k=kd_eff_isolated,
@@ -190,21 +193,11 @@ def calc_pressure_vec(
             g=gamma,
         )
 
-    return cast(
-        tuple[
-            Array2D[np.float64],
-            Array2D[np.float64],
-            Array2D[np.float64],
-            Array2D[np.float64],
-            Array1D[np.float64],
-            Array2D[np.float64],
-        ],
-        (
-            alpha_n_connected,
-            v_n_connected,
-            alpha_n_isolated,
-            v_n_isolated,
-            tau_n_out,
-            gamma_n_out,
-        ),
+    return (
+        alpha_n_connected,
+        v_n_connected,
+        alpha_n_isolated,
+        v_n_isolated,
+        tau_n_out,
+        gamma_n_out,
     )

--- a/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
+++ b/src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py
@@ -161,16 +161,10 @@ def calc_pressure_vec(
             sum_kd = sum_kd + v_con[:, j] * np.sum(
                 kd_eff_connected[:, 0:3, 0:3, j], axis=(1, 2)
             )
-    # Find the new concentration of inclusion. Initialise outputs to zero
-    # arrays matching the input shapes so that branches skipped by ``ctrl``
-    # still satisfy the non-optional return type. Callers rely on ``ctrl`` to
-    # know which outputs are meaningful.
-    alpha_n_isolated = np.zeros_like(alpha_iso)
-    alpha_n_connected = np.zeros_like(alpha_con)
-    v_n_isolated = np.zeros_like(v_iso)
-    v_n_connected = np.zeros_like(v_con)
-    gamma_n_out = np.zeros_like(gamma)
-    tau_n_out = np.zeros_like(tau)
+    # Find the new concentration of inclusion. Branches skipped by ``ctrl``
+    # are filled with zero arrays of the matching input shape so that the
+    # declared non-optional return type is honoured. Callers rely on
+    # ``ctrl`` to know which outputs are meaningful.
     if ctrl != 2 and kd_eff_isolated is not None:
         v_n_isolated, alpha_n_isolated, _, _ = _new_values(
             k=kd_eff_isolated,
@@ -181,6 +175,9 @@ def calc_pressure_vec(
             t=tau,
             g=gamma,
         )
+    else:
+        alpha_n_isolated = np.zeros_like(alpha_iso)
+        v_n_isolated = np.zeros_like(v_iso)
 
     if ctrl != 0 and kd_eff_connected is not None:
         v_n_connected, alpha_n_connected, tau_n_out, gamma_n_out = _new_values(
@@ -192,6 +189,11 @@ def calc_pressure_vec(
             t=tau,
             g=gamma,
         )
+    else:
+        alpha_n_connected = np.zeros_like(alpha_con)
+        v_n_connected = np.zeros_like(v_con)
+        tau_n_out = np.zeros_like(tau)
+        gamma_n_out = np.zeros_like(gamma)
 
     return (
         alpha_n_connected,


### PR DESCRIPTION
Closes #152. Closes #153 (duplicate of #152).

`calc_pressure_vec` in `src/rock_physics_open/t_matrix_models/t_matrix_vector/calc_pressure.py` was annotated to return a 6-tuple of non-optional `Array2D`/`Array1D` values, but several branches initialised outputs to `None` and returned them unchanged when `ctrl` skipped a branch. A `cast(...)` hid the mismatch.

Per option 2 in #152 ("return zero-arrays in the unused branches so the non-optional type is honoured"), this PR initialises the skipped outputs as zero arrays matching the input shapes (`np.zeros_like(alpha_iso)`, `np.zeros_like(v_con)`, `np.zeros_like(tau)`, etc.) and removes the `cast`. The two callers (`t_matrix_vec.py`, `run_t_matrix.py`) already use `ctrl` / `ctrl_connected` to decide which branch's outputs to consume, so observable behaviour is unchanged.

### Changes
- `calc_pressure.py`: replace `None` initialisations with `np.zeros_like(...)` of the matching input arrays; drop the `cast(...)` wrapper and the unused `cast` import.
- `run_t_matrix.py`: update the now-stale comment that said the values "can be returned as None".

### Validation
- `uv run ruff check --fix` — clean
- `uv run ruff format` — no changes
- `uv run basedpyright` — 0 errors, 0 warnings (without the `cast`)
- `uv run pytest` — 187 passed, 104 snapshots