### PR TITLE
ci: use uv to build package for release

### DIFF
--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -36,15 +36,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python (uv)
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version-file: .python-version
+          enable-cache: true
 
       - name: Build
-        run: |
-          pip install build
-          python -m build
+        run: uv build
 
       - name: Upload Package Artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Replaces the `pip install build && python -m build` step in the release build job with `uv build`, reusing the `astral-sh/setup-uv@v7` action already used by the lint workflow.

`uv build` invokes the same PEP 517 backend (`setuptools.build_meta`) and produces the same sdist + wheel artifacts in `dist/`, so the downstream `pypa/gh-action-pypi-publish` step is unaffected. `fetch-depth: 0` is preserved so `setuptools_scm` can derive the version from git tags.

Verified locally that `uv build` produces a `.tar.gz` and a `-py3-none-any.whl`, and `twine check dist/*` passes for both.

Closes #156