### PR TITLE
fix(std_functions): broaden type signatures to accept scalar inputs

### DIFF
--- a/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/hashin_shtrikman.py
@@ -7,10 +7,10 @@ from rock_physics_open.equinor_utilities.gen_utilities import dim_check_vector
 
 
 def hashin_shtrikman(
-    k1: npt.NDArray[np.float64],
-    mu1: npt.NDArray[np.float64],
-    k2: npt.NDArray[np.float64],
-    mu2: npt.NDArray[np.float64],
+    k1: npt.NDArray[np.float64] | float,
+    mu1: npt.NDArray[np.float64] | float,
+    k2: npt.NDArray[np.float64] | float,
+    mu2: npt.NDArray[np.float64] | float,
     f: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
@@ -45,10 +45,10 @@ def hashin_shtrikman(
 
 
 def hashin_shtrikman_average(
-    k1: npt.NDArray[np.float64],
-    mu1: npt.NDArray[np.float64],
-    k2: npt.NDArray[np.float64],
-    mu2: npt.NDArray[np.float64],
+    k1: npt.NDArray[np.float64] | float,
+    mu1: npt.NDArray[np.float64] | float,
+    k2: npt.NDArray[np.float64] | float,
+    mu2: npt.NDArray[np.float64] | float,
     f: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """

--- a/src/rock_physics_open/equinor_utilities/std_functions/hertz_mindlin.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/hertz_mindlin.py
@@ -5,10 +5,10 @@ import numpy.typing as npt
 def hertz_mindlin(
     k: npt.NDArray[np.float64],
     mu: npt.NDArray[np.float64],
-    phi_c: npt.NDArray[np.float64],
+    phi_c: npt.NDArray[np.float64] | float,
     p: npt.NDArray[np.float64],
     shear_red: npt.NDArray[np.float64] | float,
-    coord: npt.NDArray[np.float64] | None = None,
+    coord: npt.NDArray[np.float64] | float | None = None,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
     Hertz-Mindlin Pressure-induced moduli increase at critical porosity.

--- a/src/rock_physics_open/equinor_utilities/std_functions/moduli_velocity.py
+++ b/src/rock_physics_open/equinor_utilities/std_functions/moduli_velocity.py
@@ -1,15 +1,36 @@
-from typing import cast
+from typing import cast, overload
 
 import numpy as np
+import numpy.typing as npt
 
 from rock_physics_open.equinor_utilities.various_utilities.types import ArrayAnyDOrFloat
 
 
+@overload
 def moduli(
-    vp: ArrayAnyDOrFloat,
-    vs: ArrayAnyDOrFloat,
-    rhob: ArrayAnyDOrFloat,
-) -> tuple[ArrayAnyDOrFloat, ArrayAnyDOrFloat]:
+    vp: npt.NDArray[np.float64],
+    vs: npt.NDArray[np.float64] | float,
+    rhob: npt.NDArray[np.float64] | float,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ...
+@overload
+def moduli(
+    vp: npt.NDArray[np.float64] | float,
+    vs: npt.NDArray[np.float64],
+    rhob: npt.NDArray[np.float64] | float,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ...
+@overload
+def moduli(
+    vp: npt.NDArray[np.float64] | float,
+    vs: npt.NDArray[np.float64] | float,
+    rhob: npt.NDArray[np.float64],
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ...
+@overload
+def moduli(vp: float, vs: float, rhob: float) -> tuple[float, float]: ...
+def moduli(
+    vp: npt.NDArray[np.float64] | float,
+    vs: npt.NDArray[np.float64] | float,
+    rhob: npt.NDArray[np.float64] | float,
+) -> tuple[npt.NDArray[np.float64] | float, npt.NDArray[np.float64] | float]:
     """
     Calculate isotropic moduli from velocity and density.
 


### PR DESCRIPTION
Broadens type annotations in three `std_functions` modules so that scalar mineral constants can be passed alongside per-sample arrays without `# pyright: ignore` workarounds in downstream callers.

## Changes

- **`hertz_mindlin`** — `phi_c` and `coord` now accept `NDArray[float64] | float` (`coord` also `| None`).
- **`hashin_shtrikman`** / **`hashin_shtrikman_average`** — `k1`, `mu1`, `k2`, `mu2` now accept `NDArray[float64] | float`. `f` remains an array (per-sample mixing fraction).
- **`moduli`** — replaced the shared `ArrayAnyDOrFloat` TypeVar with a set of `@overload` signatures so each of `vp`, `vs`, `rhob` independently accepts `NDArray | float`, while preserving precise return-type inference (array if any input is an array, else float).

No runtime behaviour changes.

## Validation

- `uv run basedpyright` — 0 errors, 0 warnings
- `uv run ruff check` / `ruff format` — clean
- `uv run pytest` — 187 passed

Closes #168
Closes #169
Closes #170