### PR TITLE
chore: update dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,16 +1,34 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/" # checks workflow files in ".github/workflows"
+    directory: "/"
+    groups:
+      ci:
+        patterns:
+          - "*"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "uv"
     directory: "/"
-    schedule:
-      interval: "monthly"
     groups:
       dev:
         dependency-type: "development"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    groups:
+      pre-commit:
         patterns:
           - "*"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
updates dependabot by:

- adding `pre-commit`
- adding `cooldown`
  > as a "security layer" to allow potential critical bugs etc in dependencies to be fixed/changes before they are included in depedabot updates.