### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs and bump to latest

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python (uv)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python (uv)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
         run: uv build
 
       - name: Upload Package Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rock-physics-open-distribution
           path: dist/
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Download Package Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rock-physics-open-distribution
           path: dist/
 
       - name: Publish Package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,14 +18,14 @@ jobs:
     steps:
       - name: Create Token
         id: create-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: release-please
         id: release-please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,10 @@ jobs:
     name: ${{ matrix.python-version }} - ${{ matrix.os }}${{ matrix.module-resolution == 'lowest' && ' (lowest)' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python (uv)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true


### PR DESCRIPTION
## Summary

Hardens CI against supply-chain attacks by pinning every third-party GitHub Action to an immutable commit SHA, with the exact version as an inline comment (the convention Dependabot understands and keeps in sync).

While doing so, also bumps every action to its latest release that has cleared the 7-day Dependabot cooldown (today is 2026-05-20, so released on or before 2026-05-13).

## Changes per action

| Action | Before | After | Released |
|---|---|---|---|
| `actions/checkout` | `@v6` | `de0fac2…` # v6.0.2 | 2026-01-09 |
| `astral-sh/setup-uv` | `@v7` | `0880764…` # **v8.1.0** | 2026-04-16 |
| `actions/upload-artifact` | `@v7` | `043fb46…` # v7.0.1 | 2026-04-10 |
| `actions/download-artifact` | `@v8` | `3e5f45b…` # v8.0.1 | 2026-03-11 |
| `actions/create-github-app-token` | `@v3` | `bcd2ba4…` # v3.2.0 | 2026-05-12 |
| `googleapis/release-please-action` | `@v5` (floating, bumped by Dependabot on `main` while this PR was open) | `45996ed…` # v5.0.0 | 2026-04-22 |
| `pypa/gh-action-pypi-publish` | `@release/v1` (branch!) | `cef2210…` # v1.14.0 | 2026-04-07 |

Bold = a version bump beyond what the previous floating tag would have resolved to.

### Notes
- **`pypa/gh-action-pypi-publish`** was previously tracking the moving `release/v1` branch — the most exposed entry to supply-chain attacks. Now pinned by SHA.
- **`astral-sh/setup-uv` v8.0.0** stopped publishing floating major/minor tags (`@v8`, `@v8.1`) as a supply-chain hardening measure — only the immutable `@v8.1.0` form is available. The SHA-pin pattern used here matches their recommendation exactly.
- **`googleapis/release-please-action` v5.0.0** is a Node 24 upgrade and requires Actions Runner ≥ 2.327.1 (provided on GitHub-hosted runners). Dependabot opened a separate PR bumping the floating `@v4` → `@v5` tag while this PR was in review; resolved during rebase by keeping the SHA-pinned form.

## `--locked` enforcement

Every `uv sync` invocation in CI already uses `--locked`. The only exception is the `lowest` matrix variant in [test.yaml](.github/workflows/test.yaml), which intentionally uses `--resolution=lowest-direct` to validate that lower-bound dependency versions still work.

## Companion changes already on `main`

- Dependabot cooldown of 7 days configured for all ecosystems (`github-actions`, `uv`, `pre-commit`) in [dependabot.yaml](.github/dependabot.yaml).
