### PR TITLE
test: only use testdata fixture when reading files in it

### DIFF
--- a/tests/fixtures/testdata.py
+++ b/tests/fixtures/testdata.py
@@ -1,11 +1,9 @@
 from pathlib import Path
-from shutil import copytree
 
 import pytest
 
 
 @pytest.fixture(scope="session")
-def testdata(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    src_testdata_folder = Path(__file__).parent.parent / "data"  # tests/data
-    tmp_testdata_folder = tmp_path_factory.mktemp("testdata")
-    return copytree(src_testdata_folder, tmp_testdata_folder, dirs_exist_ok=True)
+def testdata() -> Path:
+    """The full path to the test data directory (`tests/data`), so files in it can be read as input."""
+    return Path(__file__).parent.parent / "data"

--- a/tests/sandstone_model_tests/test_sandstone_optimisation.py
+++ b/tests/sandstone_model_tests/test_sandstone_optimisation.py
@@ -56,8 +56,8 @@ def params(testdata: Path) -> SandstoneOptParams:
 
 def test_friable_optimisation(
     snapshot: SnapshotAssertion,
-    testdata: Path,
     params: SandstoneOptParams,
+    tmp_path: Path,
 ):
     assert snapshot == friable_model_optimisation(
         k_min=params.k_min,
@@ -70,14 +70,14 @@ def test_friable_optimisation(
         vp=params.vp,
         vs=params.vs,
         rhob=params.rhob,
-        file_out_str=str(testdata / "friable_model_optimisation.pkl"),
+        file_out_str=str(tmp_path / "friable_model_optimisation.pkl"),
     )
 
 
 def test_constant_cement_optimisation(
     snapshot: SnapshotAssertion,
-    testdata: Path,
     params: SandstoneOptParams,
+    tmp_path: Path,
 ):
     assert snapshot == constant_cement_model_optimisation(
         k_min=params.k_min,
@@ -92,14 +92,14 @@ def test_constant_cement_optimisation(
         vp=params.vp,
         vs=params.vs,
         rhob=params.rhob,
-        file_out_str=str(testdata / "constant_cement_model_optimisation.pkl"),
+        file_out_str=str(tmp_path / "constant_cement_model_optimisation.pkl"),
     )
 
 
 def test_patchy_cement_optimisation(
     snapshot: SnapshotAssertion,
-    testdata: Path,
     params: SandstoneOptParams,
+    tmp_path: Path,
 ):
     assert snapshot == patchy_cement_model_optimisation(
         k_min=params.k_min,
@@ -116,5 +116,5 @@ def test_patchy_cement_optimisation(
         vs=params.vs,
         rhob=params.rhob,
         phi_c=params.phi_c,
-        file_out_str=str(testdata / "patchy_cement_model_optimisation.pkl"),
+        file_out_str=str(tmp_path / "patchy_cement_model_optimisation.pkl"),
     )

--- a/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
+++ b/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
@@ -5,19 +5,19 @@ from rock_physics_open.equinor_utilities.optimisation_utilities import (
 )
 
 
-def test_opt_param_to_ascii_petec(testdata: Path):
+def test_opt_param_to_ascii_petec(testdata: Path, tmp_path: Path):
     tmatrix_parameters_petec = testdata / "petec_opt_param_test.pkl"
     opt_param_to_ascii(
         tmatrix_parameters_petec,
         display_results=False,
-        out_file=testdata / "petec_opt_param.txt",
+        out_file=tmp_path / "petec_opt_param.txt",
     )
 
 
-def test_opt_param_to_ascii_exp(testdata: Path):
+def test_opt_param_to_ascii_exp(testdata: Path, tmp_path: Path):
     tmatrix_parameters_exp = testdata / "exp_opt_param_test.pkl"
     opt_param_to_ascii(
         tmatrix_parameters_exp,
         display_results=False,
-        out_file=testdata / "exp_opt_param.txt",
+        out_file=tmp_path / "exp_opt_param.txt",
     )

--- a/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
+++ b/tests/t_matrix_model_tests/test_opt_param_to_ascii.py
@@ -5,27 +5,19 @@ from rock_physics_open.equinor_utilities.optimisation_utilities import (
 )
 
 
-def test_opt_param_to_ascii_display_petec(testdata: Path):
-    in_file = testdata / "petec_opt_param_test.pkl"
-    try:
-        opt_param_to_ascii(in_file, display_results=False)
-    except (ValueError, IOError):
-        raise ValueError(f"Not possible to read input file {in_file}")
-    out_file = testdata / "petec_opt_param.txt"
-    try:
-        opt_param_to_ascii(in_file, display_results=False, out_file=out_file)
-    except (ValueError, IOError):
-        raise ValueError(f"Not possible to write output file {out_file}")
+def test_opt_param_to_ascii_petec(testdata: Path):
+    tmatrix_parameters_petec = testdata / "petec_opt_param_test.pkl"
+    opt_param_to_ascii(
+        tmatrix_parameters_petec,
+        display_results=False,
+        out_file=testdata / "petec_opt_param.txt",
+    )
 
 
-def test_opt_param_to_ascii_display_exp(testdata: Path):
-    in_file = testdata / "exp_opt_param_test.pkl"
-    try:
-        opt_param_to_ascii(in_file, display_results=False)
-    except (ValueError, IOError):
-        raise ValueError(f"Not possible to read input file {in_file}")
-    out_file = testdata / "exp_opt_param.txt"
-    try:
-        opt_param_to_ascii(in_file, display_results=False, out_file=out_file)
-    except (ValueError, IOError):
-        raise ValueError(f"Not possible to write output file {out_file}")
+def test_opt_param_to_ascii_exp(testdata: Path):
+    tmatrix_parameters_exp = testdata / "exp_opt_param_test.pkl"
+    opt_param_to_ascii(
+        tmatrix_parameters_exp,
+        display_results=False,
+        out_file=testdata / "exp_opt_param.txt",
+    )

--- a/tests/various_utilities_tests/test_vp_vs_rho_stats.py
+++ b/tests/various_utilities_tests/test_vp_vs_rho_stats.py
@@ -6,7 +6,7 @@ from syrupy.assertion import SnapshotAssertion
 from rock_physics_open.equinor_utilities.various_utilities import vp_vs_rho_stats
 
 
-def test_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
+def test_vp_vs_rho_stats(snapshot: SnapshotAssertion, tmp_path: Path):
     rng = np.random.default_rng(123456)
     vp_obs = rng.uniform(low=0.0, high=1.0, size=100)
     vs_obs = rng.uniform(low=0.0, high=1.0, size=100)
@@ -14,7 +14,7 @@ def test_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
     vp_est = rng.uniform(low=0.0, high=1.0, size=100)
     vs_est = rng.uniform(low=0.0, high=1.0, size=100)
     rho_est = rng.uniform(low=0.0, high=1.0, size=100)
-    fname = str(testdata / "vp_vs_rho_stats.csv")
+    fname = str(tmp_path / "vp_vs_rho_stats.csv")
     file_open_mode = "w"
     disp_res = False
     vp_vs_rho_stats(
@@ -33,7 +33,7 @@ def test_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
     assert snapshot == Path(fname).read_text().strip()
 
 
-def test_multi_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
+def test_multi_vp_vs_rho_stats(snapshot: SnapshotAssertion, tmp_path: Path):
     rng = np.random.default_rng(123456)
     vp_obs = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
     vs_obs = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
@@ -43,7 +43,7 @@ def test_multi_vp_vs_rho_stats(snapshot: SnapshotAssertion, testdata: Path):
     rho_est = [rng.uniform(low=0.0, high=1.0, size=100)] * 3
     set_names = ["pytest_1", "pytest_2", "pytest_3"]
     well_names = ["pytest_well_1", "pytest_well_2", "pytest_well_3"]
-    fname = str(testdata / "multi_vp_vs_rho_stats.csv")
+    fname = str(tmp_path / "multi_vp_vs_rho_stats.csv")
     file_open_mode = "w"
     disp_res = False
     vp_vs_rho_stats(


### PR DESCRIPTION
Two small changes to tests. 

The first simply removes the wrapping try/except for `test_opt_param_to_ascii`, as the tests will naturally fail on any exceptions (so the additional try/except provides no value, and can potentially obscure other exceptions than read/write errors)

The second makes us a bit more delibirate in when we use the `testdata` fixture, vs an arbitrary `tmp_path`. The difference being `testdata` should only be used when we need to _read_ a file/data from the `tests/data` folder. `tmp_path` is built-in and should be used when a test needs to _write_ a file.